### PR TITLE
removing some redundant module prefixing

### DIFF
--- a/includes/mimetype.utils.inc
+++ b/includes/mimetype.utils.inc
@@ -5,7 +5,7 @@
  * Mimetype specific utility functions.
  */
 
-use Drupal\islandora\IslandoraMimeTypeMapper;
+use Drupal\islandora\MimeTypeMapper;
 
 /**
  * Retrieve the correct file extension for a give mimetype.
@@ -22,7 +22,7 @@ function islandora_get_extension_for_mimetype($mimetype) {
   if ($mimetype == 'text/xml') {
     return 'xml';
   }
-  $mapper = new IslandoraMimeTypeMapper(\Drupal::service('file.mime_type.guesser'));
+  $mapper = new MimeTypeMapper(\Drupal::service('file.mime_type.guesser'));
   $extensions = $mapper->getExtensionsForMimeType($mimetype);
   return !empty($extensions) ? reset($extensions) : 'bin';
 }
@@ -42,7 +42,7 @@ function islandora_get_extensions_for_mimetype($mimetype) {
   if ($mimetype == 'text/xml') {
     return ['xml'];
   }
-  $mapper = new IslandoraMimeTypeMapper(\Drupal::service('file.mime_type.guesser'));
+  $mapper = new MimeTypeMapper(\Drupal::service('file.mime_type.guesser'));
   $extensions = $mapper->getExtensionsForMimeType($mimetype);
   return $extensions;
 }

--- a/includes/regenerate_derivatives.form.inc
+++ b/includes/regenerate_derivatives.form.inc
@@ -128,14 +128,14 @@ function islandora_derivative_perform_batch_operation($function, $file, $pid, $f
 /**
  * Finished function for derivative batch regeneration.
  *
- * @param array $success
- *   An array of success passed from the batch.
+ * @param bool $success
+ *   Success passed from the batch.
  * @param array $results
  *   An array of results passed from the batch.
  * @param array $operations
  *   An array of operations passed from the batch.
  */
-function islandora_regenerate_derivative_batch_finished(array $success, array $results, array $operations) {
+function islandora_regenerate_derivative_batch_finished($success, array $results, array $operations) {
   module_load_include('inc', 'islandora', 'includes/derivatives');
   if (!empty($results['logging'])) {
     islandora_derivative_logging($results['logging']);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -12,7 +12,7 @@ use Drupal\Core\Link;
 use Drupal\Component\Utility\Unicode;
 use Drupal\Component\Utility\Xss;
 
-use Drupal\islandora\Event\IslandoraRepositoryEvent;
+use Drupal\islandora\Event\RepositoryEvent;
 
 /**
  * Convert bytes to human readable format.
@@ -203,7 +203,7 @@ function islandora_invoke_hook_list($hook, array $refinements, array $args) {
     $return = array_merge_recursive($return, $result);
   }
 
-  $event = new IslandoraRepositoryEvent($hook, $args);
+  $event = new RepositoryEvent($hook, $args);
   \Drupal::service('event_dispatcher')->dispatch($event->getEventName(), $event);
 
   return $return;

--- a/islandora.module
+++ b/islandora.module
@@ -6,7 +6,7 @@
  */
 
 use Drupal\islandora\DublinCore;
-use Drupal\islandora\Authentication\Provider\IslandoraTokenAuth;
+use Drupal\islandora\Authentication\Provider\TokenAuth;
 
 // @codingStandardsIgnoreStart
 // Common datastreams.
@@ -249,7 +249,7 @@ function islandora_user_access_check($object_or_datastream, array $permissions, 
 
   // Determine the user account to test against.
   if (!isset($user)) {
-    $token = filter_input(INPUT_GET, IslandoraTokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
+    $token = filter_input(INPUT_GET, TokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
     if ($token) {
       module_load_include('inc', 'islandora', 'includes/authtokens');
       $token_user = islandora_validate_object_token($object->id, $datastream->id, $token);
@@ -315,7 +315,7 @@ function islandora_object_datastream_tokened_access_callback($perm, $object = NU
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   $token_account = NULL;
-  $token = filter_input(INPUT_GET, IslandoraTokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
+  $token = filter_input(INPUT_GET, TokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
 
   if ($token) {
     $user = islandora_validate_object_token($object->id, $datastream->id, $token);
@@ -504,7 +504,7 @@ function islandora_object_load($object_id) {
  */
 function islandora_tokened_object_load($object_id, array $map) {
   if (array_key_exists('token', $_GET)) {
-    $token = filter_input(INPUT_GET, IslandoraTokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
+    $token = filter_input(INPUT_GET, TokenAuth::TOKEN_NAME, FILTER_SANITIZE_STRING);
     if ($token) {
       module_load_include('inc', 'islandora', 'includes/authtokens');
       $token_user = islandora_validate_object_token($object_id, $map[4], $token);
@@ -743,7 +743,7 @@ function islandora_delete_datastream(AbstractDatastream &$datastream) {
  * Implements hook_cron().
  */
 function islandora_cron() {
-  IslandoraTokenAuth::removeExpiredTokens();
+  TokenAuth::removeExpiredTokens();
 }
 
 /**

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -9,14 +9,14 @@ islandora.repository_admin:
   path: '/admin/config/islandora/core'
   defaults:
     _title: 'Configuration'
-    _form: '\Drupal\islandora\Form\IslandoraRepositoryAdmin'
+    _form: '\Drupal\islandora\Form\RepositoryAdmin'
   requirements:
     _permission: 'administer site configuration'
 islandora.metadata_display_form:
   path: '/admin/config/islandora/metadata'
   defaults:
     _title: 'Metadata Display'
-    _form: '\Drupal\islandora\Form\IslandoraMetadataDisplayForm'
+    _form: '\Drupal\islandora\Form\MetadataDisplayForm'
   requirements:
     _permission: 'administer site configuration'
 islandora.solution_packs_admin:
@@ -30,7 +30,7 @@ islandora.solution_packs_admin_form:
   path: '/admin/config/islandora/solution_pack_config/solution_packs'
   defaults:
     _title: 'Solution packs required objects'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraSolutionPacksAdmin'
+    _controller: '\Drupal\islandora\Controller\DefaultController::solutionPacksAdmin'
   requirements:
     _permission: 'add fedora datastreams'
 islandora.tools_admin:
@@ -44,22 +44,22 @@ islandora.view_default_object:
   path: '/islandora'
   defaults:
     _title: 'Islandora Repository'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewDefaultObject'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewDefaultObject'
   requirements:
     _permission: 'view fedora repository objects'
 islandora.view_default_object_0:
   path: '/islandora/object'
   defaults:
     _title: 'Object Browsing'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewDefaultObject'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewDefaultObject'
   requirements:
     _permission: 'view fedora repository objects'
 islandora.view_object:
   path: '/islandora/object/{object}'
   defaults:
     perms: 'view fedora repository objects'
-    _title_callback: '\Drupal\islandora\Controller\DefaultController::islandoraDrupalTitle'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewObject'
+    _title_callback: '\Drupal\islandora\Controller\DefaultController::drupalTitle'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewObject'
   requirements:
     _islandora_object_access: 'TRUE'
   options:
@@ -71,9 +71,9 @@ islandora.printer_object:
   defaults:
     op: 'view fedora repository objects'
     _title: 'Print Object'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraPrintObject'
+    _controller: '\Drupal\islandora\Controller\DefaultController::printObject'
   requirements:
-    _custom_access: '\Drupal\islandora\Controller\DefaultController::islandoraPrintObjectAccess'
+    _custom_access: '\Drupal\islandora\Controller\DefaultController::printObjectAccess'
   options:
     parameters:
       object:
@@ -83,9 +83,9 @@ islandora.print_object:
   defaults:
     op: 'view fedora repository objects'
     _title: 'Print Object'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraPrintObject'
+    _controller: '\Drupal\islandora\Controller\DefaultController::printObject'
   requirements:
-    _custom_access: '\Drupal\islandora\Controller\DefaultController::islandoraPrintObjectAccess'
+    _custom_access: '\Drupal\islandora\Controller\DefaultController::printObjectAccess'
   options:
     parameters:
       object:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -251,7 +251,7 @@ islandora.delete_datastream_form:
   defaults:
     perms: 'delete fedora objects and datastreams'
     _title: 'Delete data stream'
-    _form: '\Drupal\islandora\Form\IslandoraDeleteDatastreamForm'
+    _form: '\Drupal\islandora\Form\DeleteDatastreamForm'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -222,7 +222,7 @@ islandora.download_datastream:
   defaults:
     perms: 'view fedora repository objects'
     _title: 'Download datastream'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraDownloadDatastream'
+    _controller: '\Drupal\islandora\Controller\DefaultController::downloadDatastream'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -236,7 +236,7 @@ islandora.edit_datastream:
   defaults:
     perms: 'edit fedora metadata'
     _title: 'Edit datastream'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraEditDatastream'
+    _controller: '\Drupal\islandora\Controller\DefaultController::editDatastream'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -266,7 +266,7 @@ islandora.datastream_version_table:
   defaults:
     perms: 'view old datastream versions'
     _title: 'Datastream Versions'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraDatastreamVersionTable'
+    _controller: '\Drupal\islandora\Controller\DefaultController::datastreamVersionTable'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -142,7 +142,7 @@ islandora.delete_object_form:
   defaults:
     perms: 'delete fedora objects and datastreams'
     _title: 'Delete object'
-    _form: '\Drupal\islandora\Form\IslandoraDeleteObjectForm'
+    _form: '\Drupal\islandora\Form\DeleteObjectForm'
   requirements:
     _islandora_object_access: 'true'
   options:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -178,12 +178,15 @@ islandora.add_datastream_form:
 islandora.add_datastream_form_autocomplete_callback:
   path: '/islandora/object/{object}/manage/datastreams/add/autocomplete'
   defaults:
-    perm: 'add fedora datastreams'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraAddDatastreamFormAutocompleteCallback'
+    perms: 'add fedora datastreams'
+    _controller: '\Drupal\islandora\Controller\DefaultController::addDatastreamFormAutocompleteCallback'
   options:
     _admin_route: TRUE
+    parameters:
+      object:
+        type: object
   requirements:
-    _custom_access: '\Drupal\islandora\Controller\DefaultController::islandoraObjectAccessCallback'
+    _islandora_object_access: 'true'
 islandora.view_datastream:
   path: '/islandora/object/{object}/datastream/{datastream}'
   defaults:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -155,7 +155,7 @@ islandora.regenerate_object_derivatives_form:
   defaults:
     perms: 'regenerate derivatives for an object'
     _title: 'Regenerate all derivatives on an object'
-    _form: '\Drupal\islandora\Form\IslandoraRegenerateObjectDerivativesForm'
+    _form: '\Drupal\islandora\Form\RegenerateObjectDerivativesForm'
   requirements:
     _islandora_object_access: 'true'
   options:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -129,7 +129,7 @@ islandora.object_properties_form:
   defaults:
     perms: 'manage object properties'
     _title: 'Properties'
-    _form: '\Drupal\islandora\Form\IslandoraObjectPropertiesForm'
+    _form: '\Drupal\islandora\Form\ObjectPropertiesForm'
   requirements:
     _islandora_object_access: 'TRUE'
   options:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -192,8 +192,8 @@ islandora.view_datastream:
   defaults:
     perms: 'view fedora repository objects'
     download: false
-    _title_callback: '\Drupal\islandora\Controller\DefaultController::islandoraViewDatastreamTitle'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewDatastream'
+    _title_callback: '\Drupal\islandora\Controller\DefaultController::viewDatastreamTitle'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewDatastream'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -207,7 +207,7 @@ islandora.view_datastream_view:
   defaults:
     perms: 'view fedora repository objects'
     _title: 'View'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewDatastream'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewDatastream'
   requirements:
     _islandora_datastream_access: '{datastream}'
   options:
@@ -282,7 +282,7 @@ islandora.view_datastream_version:
     perms: 'view old datastream versions'
     _title: 'View Datastream Version'
     download: false
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraViewDatastream'
+    _controller: '\Drupal\islandora\Controller\DefaultController::viewDatastream'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -297,7 +297,7 @@ islandora.datastream_version_replace_form:
   defaults:
     perms: 'replace a datastream with new content, preserving version history'
     _title: 'Replace Datastream'
-    _form: '\Drupal\islandora\Form\IslandoraDatastreamVersionReplaceForm'
+    _form: '\Drupal\islandora\Form\DatastreamVersionReplaceForm'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -311,7 +311,7 @@ islandora.delete_datastream_version_form:
   defaults:
     perms: 'delete fedora objects and datastreams'
     _title: 'Delete datastream version'
-    _form: '\Drupal\islandora\Form\IslandoraDeleteDatastreamVersionForm'
+    _form: '\Drupal\islandora\Form\DeleteDatastreamVersionForm'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -326,7 +326,7 @@ islandora.revert_datastream_version_form:
   defaults:
     perms: 'revert to old datastream'
     _title: 'Revert to datastream version'
-    _form: '\Drupal\islandora\Form\IslandoraRevertDatastreamVersionForm'
+    _form: '\Drupal\islandora\Form\RevertDatastreamVersionForm'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -341,7 +341,7 @@ islandora.regenerate_datastream_derivative_form:
   defaults:
     perms: 'regenerate derivatives for an object'
     _title: 'Regenrate datastream derivative'
-    _form: '\Drupal\islandora\Form\IslandoraRegenerateDatastreamDerivativeForm'
+    _form: '\Drupal\islandora\Form\RegenerateDatastreamDerivativeForm'
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:
@@ -354,7 +354,7 @@ islandora.event_status:
   path: '/islandora/event-status'
   defaults:
     _title: 'Event Status'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraEventStatus'
+    _controller: '\Drupal\islandora\Controller\DefaultController::eventStatus'
   requirements:
     # No access restriction due to D7 legacy.
     _access: 'TRUE'
@@ -362,13 +362,13 @@ islandora.content_model_autocomplete:
   path: '/islandora/autocomplete/content-models'
   defaults:
     _title: 'Autocomplete callback'
-    _controller: '\Drupal\islandora\Controller\DefaultController::islandoraContentModelAutocomplete'
+    _controller: '\Drupal\islandora\Controller\DefaultController::contentModelAutocomplete'
   requirements:
     _permission: 'administer site configuration'
 islandora.deleted_objects_manage_form:
   path: '/admin/config/islandora/restore'
   defaults:
     _title: 'Manage Deleted Objects'
-    _form: '\Drupal\islandora\Form\IslandoraManageDeletedObjectsForm'
+    _form: '\Drupal\islandora\Form\ManageDeletedObjectsForm'
   requirements:
     _permission: 'manage deleted objects'

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -167,7 +167,7 @@ islandora.add_datastream_form:
   defaults:
     perms: 'add fedora datastreams'
     _title: 'Add a datastream'
-    _form: '\Drupal\islandora\Form\IslandoraAddDatastreamForm'
+    _form: '\Drupal\islandora\Form\AddDatastreamForm'
   requirements:
     _islandora_object_access: 'true'
   options:

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -1,24 +1,24 @@
 services:
   object:
-    class: Drupal\islandora\ParamConverter\IslandoraObjectParamConverter
+    class: Drupal\islandora\ParamConverter\ObjectParamConverter
     arguments: ['@config.factory']
     tags:
       - { name: paramconverter }
   access_check.object:
-    class: Drupal\islandora\Access\IslandoraObjectAccess
+    class: Drupal\islandora\Access\ObjectAccess
     arguments: ['@config.factory']
     tags:
       - { name: access_check, applies_to: _islandora_object_access }
   datastream:
-    class: Drupal\islandora\ParamConverter\IslandoraDatastreamParamConverter
+    class: Drupal\islandora\ParamConverter\DatastreamParamConverter
     tags:
       - { name: paramconverter }
   access_check.datastream:
-    class: Drupal\islandora\Access\IslandoraDatastreamAccess
+    class: Drupal\islandora\Access\DatastreamAccess
     tags:
       - { name: access_check, applies_to: _islandora_datastream_access }
   authentication.islandora_token:
-    class: Drupal\islandora\Authentication\Provider\IslandoraTokenAuth
+    class: Drupal\islandora\Authentication\Provider\TokenAuth
     arguments: ['@config.factory', '@entity.manager']
     tags:
       - {name: authentication_provider, provider_id: islandora_auth_token, global: TRUE, priority: 1}

--- a/src/Access/DatastreamAccess.php
+++ b/src/Access/DatastreamAccess.php
@@ -5,34 +5,23 @@ namespace Drupal\islandora\Access;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use AbstractObject;
+use AbstractDatastream;
 
 /**
- * Access checking for objects within Islandora.
+ * Access checking for datastreams on objects within Islandora.
  */
-class IslandoraObjectAccess implements AccessInterface {
-  /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
+class DatastreamAccess implements AccessInterface {
 
   /**
-   * Constructor.
-   */
-  public function __construct(ConfigFactoryInterface $configFactory) {
-    $this->configFactory = $configFactory;
-  }
-
-  /**
-   * Whether the user has access to an object.
+   * Whether the user has access to a datastream on an object.
    *
    * @param string|array $perms
    *   A singular permission or an array of permissions to be evalulated.
-   * @param string|AbstractObject $object
-   *   A string of the default 'root' is being based through, a loaded Fedora
-   *   object otherwise.
+   * @param \AbstractObject $object
+   *   A loaded Fedora object.
+   * @param \AbstractDatastream $datastream
+   *   The loaded datastream being accessed.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   User being validated against.
    * @param string $islandora_access_conjunction
@@ -43,28 +32,25 @@ class IslandoraObjectAccess implements AccessInterface {
    * @return \Drupal\Core\Access\AccessResult|\Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden|\Drupal\Core\Access\AccessResultNeutral
    *   Whether the user has access in AccessResult object form.
    */
-  public function access($perms, $object, AccountInterface $account, $islandora_access_conjunction = 'OR') {
+  public function access($perms, AbstractObject $object, AbstractDatastream $datastream, AccountInterface $account, $islandora_access_conjunction = 'OR') {
     module_load_include('inc', 'islandora', 'includes/utilities');
     // XXX: This seems so very dumb but given how empty slugs don't play nice
     // in Drupal as defaults this needs to be the case. If it's possible to get
     // around this by making the empty slug route in YAML or a custom Routing
     // object we can remove this.
-    $object = islandora_object_load($object === 'root' ?
-      $this->configFactory->get('islandora.settings')->get('islandora_repository_pid') :
-      $object);
-    if (!$object && !islandora_describe_repository()) {
+    if (!$datastream && !islandora_describe_repository()) {
       islandora_display_repository_inaccessible_message();
       return AccessResult::forbidden();
     }
     if (is_array($perms)) {
       $result = AccessResult::neutral();
       foreach ($perms as $perm) {
-        $result = $islandora_access_conjunction == 'AND' ? $result->andIf(AccessResult::allowedIf(islandora_object_access($perm, $object, $account))) : $result->orIf(AccessResult::allowedIf(islandora_object_access($perm, $object, $account)));
+        $result = $islandora_access_conjunction == 'AND' ? $result->andIf(AccessResult::allowedIf(islandora_datastream_access($perm, $datastream, $account))) : $result->orIf(AccessResult::allowedIf(islandora_datastream_access($perm, $datastream, $account)));
       }
       return $result;
     }
     else {
-      return AccessResult::allowedIf(islandora_object_access($perms, $object, $account));
+      return AccessResult::allowedIf(islandora_datastream_access($perms, $datastream, $account));
     }
   }
 

--- a/src/Access/ObjectAccess.php
+++ b/src/Access/ObjectAccess.php
@@ -5,23 +5,34 @@ namespace Drupal\islandora\Access;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
-use AbstractObject;
-use AbstractDatastream;
+use Drupal\Core\Config\ConfigFactoryInterface;
 
 /**
- * Access checking for datastreams on objects within Islandora.
+ * Access checking for objects within Islandora.
  */
-class IslandoraDatastreamAccess implements AccessInterface {
+class ObjectAccess implements AccessInterface {
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
   /**
-   * Whether the user has access to a datastream on an object.
+   * Constructor.
+   */
+  public function __construct(ConfigFactoryInterface $configFactory) {
+    $this->configFactory = $configFactory;
+  }
+
+  /**
+   * Whether the user has access to an object.
    *
    * @param string|array $perms
    *   A singular permission or an array of permissions to be evalulated.
-   * @param \AbstractObject $object
-   *   A loaded Fedora object.
-   * @param \AbstractDatastream $datastream
-   *   The loaded datastream being accessed.
+   * @param string|AbstractObject $object
+   *   A string of the default 'root' is being based through, a loaded Fedora
+   *   object otherwise.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   User being validated against.
    * @param string $islandora_access_conjunction
@@ -32,25 +43,28 @@ class IslandoraDatastreamAccess implements AccessInterface {
    * @return \Drupal\Core\Access\AccessResult|\Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden|\Drupal\Core\Access\AccessResultNeutral
    *   Whether the user has access in AccessResult object form.
    */
-  public function access($perms, AbstractObject $object, AbstractDatastream $datastream, AccountInterface $account, $islandora_access_conjunction = 'OR') {
+  public function access($perms, $object, AccountInterface $account, $islandora_access_conjunction = 'OR') {
     module_load_include('inc', 'islandora', 'includes/utilities');
     // XXX: This seems so very dumb but given how empty slugs don't play nice
     // in Drupal as defaults this needs to be the case. If it's possible to get
     // around this by making the empty slug route in YAML or a custom Routing
     // object we can remove this.
-    if (!$datastream && !islandora_describe_repository()) {
+    $object = islandora_object_load($object === 'root' ?
+      $this->configFactory->get('islandora.settings')->get('islandora_repository_pid') :
+      $object);
+    if (!$object && !islandora_describe_repository()) {
       islandora_display_repository_inaccessible_message();
       return AccessResult::forbidden();
     }
     if (is_array($perms)) {
       $result = AccessResult::neutral();
       foreach ($perms as $perm) {
-        $result = $islandora_access_conjunction == 'AND' ? $result->andIf(AccessResult::allowedIf(islandora_datastream_access($perm, $datastream, $account))) : $result->orIf(AccessResult::allowedIf(islandora_datastream_access($perm, $datastream, $account)));
+        $result = $islandora_access_conjunction == 'AND' ? $result->andIf(AccessResult::allowedIf(islandora_object_access($perm, $object, $account))) : $result->orIf(AccessResult::allowedIf(islandora_object_access($perm, $object, $account)));
       }
       return $result;
     }
     else {
-      return AccessResult::allowedIf(islandora_datastream_access($perms, $datastream, $account));
+      return AccessResult::allowedIf(islandora_object_access($perms, $object, $account));
     }
   }
 

--- a/src/Authentication/Provider/TokenAuth.php
+++ b/src/Authentication/Provider/TokenAuth.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
  * These are to be used when dealing with applications such as Djatoka that do
  * not pass through credentials.
  */
-class IslandoraTokenAuth implements AuthenticationProviderFilterInterface, AuthenticationProviderInterface {
+class TokenAuth implements AuthenticationProviderFilterInterface, AuthenticationProviderInterface {
 
   // Token lifespan(seconds): after this duration the token expires.
   // 5 minutes.

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -156,7 +156,7 @@ class DefaultController extends ControllerBase {
   /**
    * Islandora printer object.
    */
-  public static function islandoraPrinterObject(AbstractObject $object) {
+  public static function printerObject(AbstractObject $object) {
     $output = [];
     $temp_arr = [];
 
@@ -173,35 +173,6 @@ class DefaultController extends ControllerBase {
     // Prompt to print.
     $output['#attached']['library'][] = 'islandora/islandora-print-js';
     return $output;
-  }
-
-  /**
-   * Islandora object access.
-   */
-  public function islandoraObjectAccess($op, $object, AccountInterface $user = NULL) {
-    $cache = &drupal_static(__FUNCTION__);
-    if (!is_object($object)) {
-      // The object could not be loaded... Presumably, we don't have
-      // permission.
-      return FALSE;
-    }
-    if ($user === NULL) {
-      $user = $this->currentUser();
-    }
-
-    // Populate the cache on a miss.
-    if (!isset($cache[$op][$object->id][$user->id()])) {
-      module_load_include('inc', 'islandora', 'includes/utilities');
-
-      $results = islandora_invoke_hook_list('islandora_object_access', $object->models, [
-        $op,
-        $object,
-        $user,
-      ]);
-      // Nothing returned FALSE, and something returned TRUE.
-      $cache[$op][$object->id][$user->id()] = (!in_array(FALSE, $results, TRUE) && in_array(TRUE, $results, TRUE));
-    }
-    return $cache[$op][$object->id][$user->id()];
   }
 
   /**
@@ -223,25 +194,6 @@ class DefaultController extends ControllerBase {
       '#theme' => 'islandora_object_print',
       '#object' => $object,
     ];
-  }
-
-  /**
-   * Object management access callback.
-   */
-  public function islandoraObjectManageAccessCallback($perms, $object = NULL, AccountInterface $account = NULL) {
-    module_load_include('inc', 'islandora', 'includes/utilities');
-
-    if (!$object && !islandora_describe_repository()) {
-      islandora_display_repository_inaccessible_message();
-      return FALSE;
-    }
-
-    $has_access = FALSE;
-    for ($i = 0; $i < count($perms) && !$has_access; $i++) {
-      $has_access = $has_access || islandora_object_access($perms[$i], $object, $account);
-    }
-
-    return $has_access;
   }
 
   /**
@@ -369,14 +321,14 @@ class DefaultController extends ControllerBase {
    *   A BinaryFileResponse if it's a ranged request, a StreamedResponse
    *   otherwise.
    */
-  public function islandoraDownloadDatastream(AbstractDatastream $datastream) {
+  public function downloadDatastream(AbstractDatastream $datastream) {
     return $this->viewDatastream($datastream, TRUE);
   }
 
   /**
    * Page callback for editing a datastream.
    */
-  public function islandoraEditDatastream(AbstractDatastream $datastream) {
+  public function editDatastream(AbstractDatastream $datastream) {
     module_load_include('inc', 'islandora', 'includes/utilities');
 
     $edit_registry = islandora_build_datastream_edit_registry($datastream);
@@ -415,7 +367,7 @@ class DefaultController extends ControllerBase {
   /**
    * Page callback for the datastream version table.
    */
-  public function islandoraDatastreamVersionTable(AbstractDatastream $datastream) {
+  public function datastreamVersionTable(AbstractDatastream $datastream) {
     module_load_include('inc', 'islandora', 'includes/datastream.version');
     return islandora_datastream_version_table($datastream);
   }

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -8,7 +8,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Render\Renderer;
 
-use Drupal\islandora\Form\IslandoraSolutionPackForm;
+use Drupal\islandora\Form\SolutionPackForm;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -73,7 +73,7 @@ class DefaultController extends ControllerBase {
       // systems table for consistency in the interface.
       $solution_pack_name = $solution_pack_info['title'];
       $objects = array_filter($solution_pack_info['objects']);
-      $class_name = IslandoraSolutionPackForm::class;
+      $class_name = SolutionPackForm::class;
 
       $output[$solution_pack_module] = $this->formBuilder()->getForm($class_name, $solution_pack_module, $solution_pack_name, $objects);
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -271,7 +271,7 @@ class DefaultController extends ControllerBase {
   /**
    * Datastream title callback.
    */
-  public function islandoraViewDatastreamTitle(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
+  public function viewDatastreamTitle(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
     return $datastream->id;
   }
 
@@ -290,7 +290,7 @@ class DefaultController extends ControllerBase {
    *   A BinaryFileResponse if it's a ranged request, a StreamedResponse
    *   otherwise.
    */
-  public function islandoraViewDatastream(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
+  public function viewDatastream(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
     module_load_include('inc', 'islandora', 'includes/mimetype.utils');
     module_load_include('inc', 'islandora', 'includes/datastream');
 
@@ -370,7 +370,7 @@ class DefaultController extends ControllerBase {
    *   otherwise.
    */
   public function islandoraDownloadDatastream(AbstractDatastream $datastream) {
-    return $this->islandoraViewDatastream($datastream, TRUE);
+    return $this->viewDatastream($datastream, TRUE);
   }
 
   /**
@@ -423,7 +423,7 @@ class DefaultController extends ControllerBase {
   /**
    * Page callback for session status messages.
    */
-  public function islandoraEventStatus() {
+  public function eventStatus() {
     $results = FALSE;
     if (isset($_SESSION['islandora_event_messages'])) {
       foreach ($_SESSION['islandora_event_messages'] as $message) {
@@ -439,7 +439,7 @@ class DefaultController extends ControllerBase {
   /**
    * Autocomplete the content model name.
    */
-  public function islandoraContentModelAutocomplete(Request $request) {
+  public function contentModelAutocomplete(Request $request) {
     module_load_include('inc', 'islandora', 'includes/content_model.autocomplete');
     $string = $request->query->get('q');
     $content_models = islandora_get_content_model_names();

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -102,18 +102,6 @@ class DefaultController extends ControllerBase {
   }
 
   /**
-   * Access callback for Drupal object.
-   */
-  public function islandoraObjectAccessCallback($perm, $object, AccountInterface $account) {
-    module_load_include('inc', 'islandora', 'includes/utilities');
-    if (!$object && !islandora_describe_repository()) {
-      islandora_display_repository_inaccessible_message();
-      return FALSE;
-    }
-    return AccessResult::allowedIf(islandora_object_access($perm, $object, $account));
-  }
-
-  /**
    * View islandora object.
    */
   public function viewObject(AbstractObject $object, Request $currentRequest) {
@@ -261,7 +249,7 @@ class DefaultController extends ControllerBase {
    *
    * It lists the missing required (may be optional) datastreams.
    */
-  public function islandoraAddDatastreamFormAutocompleteCallback(AbstractObject $object, Request $request) {
+  public function addDatastreamFormAutocompleteCallback(AbstractObject $object, Request $request) {
     module_load_include('inc', 'islandora', 'includes/content_model');
     module_load_include('inc', 'islandora', 'includes/utilities');
     $query = $request->query->get('q');

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -57,7 +57,7 @@ class DefaultController extends ControllerBase {
    *
    * @throws \Exception
    */
-  public function islandoraSolutionPacksAdmin() {
+  public function solutionPacksAdmin() {
     module_load_include('inc', 'islandora', 'includes/utilities');
     module_load_include('inc', 'islandora', 'includes/solution_packs');
 
@@ -87,7 +87,7 @@ class DefaultController extends ControllerBase {
    * Redirects to the view of the object indicated by the Drupal variable
    * 'islandora_repository_pid'.
    */
-  public function islandoraViewDefaultObject() {
+  public function viewDefaultObject() {
     $pid = $this->config('islandora.settings')->get('islandora_repository_pid');
     return $this->redirect('islandora.view_object', ['object' => $pid]);
   }
@@ -95,7 +95,7 @@ class DefaultController extends ControllerBase {
   /**
    * Title callback for Drupal title to be the object label.
    */
-  public function islandoraDrupalTitle(AbstractObject $object) {
+  public function drupalTitle(AbstractObject $object) {
     module_load_include('inc', 'islandora', 'includes/breadcrumb');
     // drupal_set_breadcrumb(islandora_get_breadcrumbs($object));
     return $object->label;
@@ -116,7 +116,7 @@ class DefaultController extends ControllerBase {
   /**
    * View islandora object.
    */
-  public function islandoraViewObject(AbstractObject $object, Request $currentRequest) {
+  public function viewObject(AbstractObject $object, Request $currentRequest) {
     module_load_include('inc', 'islandora', 'includes/breadcrumb');
     module_load_include('inc', 'islandora', 'includes/utilities');
     // XXX: This seems so very dumb but given how empty slugs don't play nice
@@ -160,7 +160,7 @@ class DefaultController extends ControllerBase {
   /**
    * Access callback for printing an object.
    */
-  public function islandoraPrintObjectAccess($op, $object, AccountInterface $account) {
+  public function printObjectAccess($op, $object, AccountInterface $account) {
     $object = islandora_object_load($object);
     return AccessResult::allowedIf(islandora_print_object_access($op, $object, $account));
   }
@@ -229,7 +229,7 @@ class DefaultController extends ControllerBase {
    * @return array
    *   A renderable array.
    */
-  public function islandoraPrintObject(AbstractObject $object) {
+  public function printObject(AbstractObject $object) {
     return [
       '#title' => $object->label,
       '#theme' => 'islandora_object_print',

--- a/src/Event/RepositoryEvent.php
+++ b/src/Event/RepositoryEvent.php
@@ -8,7 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 /**
  * Represent our hooks/events, as used by Rules.
  */
-class IslandoraRepositoryEvent extends Event {
+class RepositoryEvent extends Event {
   /**
    * The name of the event being triggered.
    *

--- a/src/Form/AddDatastreamForm.php
+++ b/src/Form/AddDatastreamForm.php
@@ -17,7 +17,7 @@ use AbstractObject;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraAddDatastreamForm extends FormBase {
+class AddDatastreamForm extends FormBase {
   /**
    * File entity storage.
    *

--- a/src/Form/AddDatastreamForm.php
+++ b/src/Form/AddDatastreamForm.php
@@ -85,7 +85,8 @@ class AddDatastreamForm extends FormBase {
             '::dsidStartsWithLetter',
             '::dsidIsValid',
           ],
-          '#autocomplete_path' => "islandora/object/{$object->id}/manage/datastreams/add/autocomplete",
+          '#autocomplete_route_name' => 'islandora.add_datastream_form_autocomplete_callback',
+          '#autocomplete_route_parameters' => ['object' => $object->id],
         ],
         'label' => [
           '#title' => 'Datastream Label',

--- a/src/Form/DatastreamVersionReplaceForm.php
+++ b/src/Form/DatastreamVersionReplaceForm.php
@@ -15,7 +15,7 @@ use AbstractDatastream;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraDatastreamVersionReplaceForm extends FormBase {
+class DatastreamVersionReplaceForm extends FormBase {
   /**
    * File entity storage.
    *

--- a/src/Form/DeleteDatastreamForm.php
+++ b/src/Form/DeleteDatastreamForm.php
@@ -14,7 +14,7 @@ use AbstractObject;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraDeleteDatastreamForm extends ConfirmFormBase {
+class DeleteDatastreamForm extends ConfirmFormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/DeleteDatastreamVersionForm.php
+++ b/src/Form/DeleteDatastreamVersionForm.php
@@ -13,7 +13,7 @@ use AbstractDatastream;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraDeleteDatastreamVersionForm extends ConfirmFormBase {
+class DeleteDatastreamVersionForm extends ConfirmFormBase {
   protected $datastream;
 
   /**

--- a/src/Form/DeleteObjectForm.php
+++ b/src/Form/DeleteObjectForm.php
@@ -13,7 +13,7 @@ use AbstractObject;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraDeleteObjectForm extends ConfirmFormBase {
+class DeleteObjectForm extends ConfirmFormBase {
   /**
    * The object on which is being operated.
    *

--- a/src/Form/IngestForm.php
+++ b/src/Form/IngestForm.php
@@ -11,7 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraIngestForm extends FormBase {
+class IngestForm extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ManageDeletedObjectsForm.php
+++ b/src/Form/ManageDeletedObjectsForm.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Builds the manage deleted object form.
  */
-class IslandoraManageDeletedObjectsForm extends FormBase {
+class ManageDeletedObjectsForm extends FormBase {
 
   protected $moduleHandler;
 

--- a/src/Form/MetadataDisplayForm.php
+++ b/src/Form/MetadataDisplayForm.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Base class for configuration forms in Islandora that require invoking hooks.
  */
-class IslandoraMetadataDisplayForm extends IslandoraModuleHandlerAdminForm {
+class MetadataDisplayForm extends IslandoraModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/MetadataDisplayForm.php
+++ b/src/Form/MetadataDisplayForm.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Base class for configuration forms in Islandora that require invoking hooks.
  */
-class MetadataDisplayForm extends IslandoraModuleHandlerAdminForm {
+class MetadataDisplayForm extends ModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/ModuleHandlerAdminForm.php
+++ b/src/Form/ModuleHandlerAdminForm.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Configuration for the Islandora module.
  */
-abstract class IslandoraModuleHandlerAdminForm extends ConfigFormBase {
+abstract class ModuleHandlerAdminForm extends ConfigFormBase {
 
   protected $moduleHandler;
 

--- a/src/Form/ObjectPropertiesForm.php
+++ b/src/Form/ObjectPropertiesForm.php
@@ -15,7 +15,7 @@ use AbstractObject;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraObjectPropertiesForm extends FormBase {
+class ObjectPropertiesForm extends FormBase {
 
   /**
    * {@inheritdoc}

--- a/src/Form/RegenerateDatastreamDerivativeForm.php
+++ b/src/Form/RegenerateDatastreamDerivativeForm.php
@@ -13,7 +13,7 @@ use AbstractDatastream;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraRegenerateDatastreamDerivativeForm extends ConfirmFormBase {
+class RegenerateDatastreamDerivativeForm extends ConfirmFormBase {
 
   /**
    * The object in which we are operating.

--- a/src/Form/RegenerateObjectDerivativesForm.php
+++ b/src/Form/RegenerateObjectDerivativesForm.php
@@ -13,7 +13,7 @@ use AbstractObject;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraRegenerateObjectDerivativesForm extends ConfirmFormBase {
+class RegenerateObjectDerivativesForm extends ConfirmFormBase {
 
   /**
    * The object on which we are operating.

--- a/src/Form/RepositoryAdmin.php
+++ b/src/Form/RepositoryAdmin.php
@@ -8,7 +8,7 @@ use RepositoryException;
 /**
  * Configuration for the Islandora module.
  */
-class IslandoraRepositoryAdmin extends IslandoraModuleHandlerAdminForm {
+class RepositoryAdmin extends IslandoraModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/RepositoryAdmin.php
+++ b/src/Form/RepositoryAdmin.php
@@ -8,7 +8,7 @@ use RepositoryException;
 /**
  * Configuration for the Islandora module.
  */
-class RepositoryAdmin extends IslandoraModuleHandlerAdminForm {
+class RepositoryAdmin extends ModuleHandlerAdminForm {
 
   /**
    * {@inheritdoc}

--- a/src/Form/RevertDatastreamVersionForm.php
+++ b/src/Form/RevertDatastreamVersionForm.php
@@ -13,7 +13,7 @@ use AbstractDatastream;
  *
  * @package \Drupal\islandora\Form
  */
-class IslandoraRevertDatastreamVersionForm extends ConfirmFormBase {
+class RevertDatastreamVersionForm extends ConfirmFormBase {
   /**
    * The datastream on which is being operated.
    *

--- a/src/Form/SolutionPackForm.php
+++ b/src/Form/SolutionPackForm.php
@@ -17,11 +17,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use AbstractObject;
 
 /**
- * Class IslandoraSolutionPackForm.
+ * Class SolutionPackForm.
  *
  * @package Drupal\islandora\Form
  */
-class IslandoraSolutionPackForm extends FormBase {
+class SolutionPackForm extends FormBase {
 
   protected $moduleHandler;
   protected $renderer;

--- a/src/MimeTypeMapper.php
+++ b/src/MimeTypeMapper.php
@@ -13,7 +13,7 @@ use Drupal\Core\File\MimeType\ExtensionMimeTypeGuesser;
  *
  * @see https://www.drupal.org/node/2311679
  */
-class IslandoraMimeTypeMapper {
+class MimeTypeMapper {
 
   /**
    * The extension MIME type guesser.

--- a/src/ParamConverter/DatastreamParamConverter.php
+++ b/src/ParamConverter/DatastreamParamConverter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Routing\Route;
 /**
  * Datastream parameter converter class.
  */
-class IslandoraDatastreamParamConverter implements ParamConverterInterface {
+class DatastreamParamConverter implements ParamConverterInterface {
 
   /**
    * Datastream parameter converter method.

--- a/src/ParamConverter/ObjectParamConverter.php
+++ b/src/ParamConverter/ObjectParamConverter.php
@@ -10,7 +10,7 @@ use Symfony\Component\Routing\Route;
 /**
  * Object parameter converter class.
  */
-class IslandoraObjectParamConverter implements ParamConverterInterface {
+class ObjectParamConverter implements ParamConverterInterface {
 
   private $config;
 

--- a/src/Plugin/Condition/ObjectHasDatastream.php
+++ b/src/Plugin/Condition/ObjectHasDatastream.php
@@ -22,7 +22,7 @@ use AbstractObject;
  *   }
  * )
  */
-class IslandoraObjectHasDatastream extends RulesConditionBase {
+class ObjectHasDatastream extends RulesConditionBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Condition/ObjectHasRelationship.php
+++ b/src/Plugin/Condition/ObjectHasRelationship.php
@@ -23,7 +23,7 @@ use AbstractObject;
  *   }
  * )
  */
-class IslandoraObjectHasRelationship extends RulesConditionBase {
+class ObjectHasRelationship extends RulesConditionBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Condition/RulesDatastreamHasXpath.php
+++ b/src/Plugin/Condition/RulesDatastreamHasXpath.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\rules\Core\RulesConditionBase;
-use Drupal\islandora\TypedData\IslandoraXPathTrait;
+use Drupal\islandora\TypedData\XPathTrait;
 use Drupal\taxonomy\VocabularyInterface;
 use AbstractObject;
 
@@ -31,8 +31,8 @@ use AbstractObject;
  *   }
  * )
  */
-class IslandoraRulesDatastreamHasXpath extends RulesConditionBase {
-  use IslandoraXPathTrait;
+class RulesDatastreamHasXpath extends RulesConditionBase {
+  use XPathTrait;
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/DataType/DOMElementData.php
+++ b/src/Plugin/DataType/DOMElementData.php
@@ -10,9 +10,9 @@ use Drupal\islandora\TypedData\Proxy;
  * @DataType(
  *   id = "islandora_domelement",
  *   label = @Translation("Islandora DOMElement"),
- *   definition_class = "\Drupal\islandora\TypedData\IslandoraDOMNodeDataDefinition"
+ *   definition_class = "\Drupal\islandora\TypedData\DOMNodeDataDefinition"
  * )
  */
-class IslandoraDOMElementData extends Proxy {
+class DOMElementData extends Proxy {
   // Nothing to do...
 }

--- a/src/Plugin/DataType/DOMNodeData.php
+++ b/src/Plugin/DataType/DOMNodeData.php
@@ -10,9 +10,9 @@ use Drupal\islandora\TypedData\Proxy;
  * @DataType(
  *   id = "islandora_domnode",
  *   label = @Translation("Islandora DOMNode"),
- *   definition_class = "\Drupal\islandora\TypedData\IslandoraDOMNodeDataDefinition"
+ *   definition_class = "\Drupal\islandora\TypedData\DOMNodeDataDefinition"
  * )
  */
-class IslandoraDOMNodeData extends Proxy {
+class DOMNodeData extends Proxy {
   // Nothing to do...
 }

--- a/src/Plugin/DataType/DOMXPath.php
+++ b/src/Plugin/DataType/DOMXPath.php
@@ -10,10 +10,10 @@ use Drupal\islandora\TypedData\Proxy;
  * @DataType(
  *   id = "islandora_domxpath",
  *   label = @Translation("DOMXPath Instance"),
- *   definition_class = "\Drupal\islandora\TypedData\IslandoraDOMXPathDataDefinition"
+ *   definition_class = "\Drupal\islandora\TypedData\DOMXPathDataDefinition"
  * )
  */
-class IslandoraDOMXPath extends Proxy {
+class DOMXPath extends Proxy {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/DataType/DatastreamData.php
+++ b/src/Plugin/DataType/DatastreamData.php
@@ -10,9 +10,9 @@ use Drupal\islandora\TypedData\Proxy;
  * @DataType(
  *   id = "islandora_datastream",
  *   label = @Translation("Islandora Datastream"),
- *   definition_class = "\Drupal\islandora\TypedData\IslandoraDatastreamDataDefinition"
+ *   definition_class = "\Drupal\islandora\TypedData\DatastreamDataDefinition"
  * )
  */
-class IslandoraDatastreamData extends Proxy {
+class DatastreamData extends Proxy {
   // Nothing new...
 }

--- a/src/Plugin/DataType/ObjectData.php
+++ b/src/Plugin/DataType/ObjectData.php
@@ -10,9 +10,9 @@ use Drupal\islandora\TypedData\Proxy;
  * @DataType(
  *   id = "islandora_object",
  *   label = @Translation("Islandora Object"),
- *   definition_class = "\Drupal\islandora\TypedData\IslandoraObjectDataDefinition"
+ *   definition_class = "\Drupal\islandora\TypedData\ObjectDataDefinition"
  * )
  */
-class IslandoraObjectData extends Proxy {
+class ObjectData extends Proxy {
   // Nothing to do...
 }

--- a/src/Plugin/RulesAction/ObjectAddRelationship.php
+++ b/src/Plugin/RulesAction/ObjectAddRelationship.php
@@ -2,15 +2,15 @@
 
 namespace Drupal\islandora\Plugin\RulesAction;
 
-use Drupal\rules\Engine\RulesActionBase;
+use Drupal\rules\Core\RulesActionBase;
 use AbstractObject;
 
 /**
- * Rules action; remove a relationship from an object.
+ * Rules action; add a relationship to an object.
  *
  * @RulesAction(
- *   id = "islandora_object_remove_relationship",
- *   label = @Translation("Remove a relationship from an object"),
+ *   id = "islandora_object_add_relationship",
+ *   label = @Translation("Add a relationship to an object"),
  *   category = @Translation("Islandora"),
  *   context = {
  *     "subject" = @ContextDefinition("islandora_object",
@@ -23,13 +23,13 @@ use AbstractObject;
  *   }
  * )
  */
-class IslandoraObjectRemoveRelationship extends RulesActionBase {
+class ObjectAddRelationship extends RulesActionBase {
 
   /**
    * {@inheritdoc}
    */
   protected function doExecute(AbstractObject $subject, $pred_uri, $pred, $object, $type) {
-    $subject->relationships->remove($pred_uri, $pred, $object, $type);
+    $subject->relationships->add($pred_uri, $pred, $object, $type);
   }
 
 }

--- a/src/Plugin/RulesAction/ObjectRemoveRelationship.php
+++ b/src/Plugin/RulesAction/ObjectRemoveRelationship.php
@@ -2,15 +2,15 @@
 
 namespace Drupal\islandora\Plugin\RulesAction;
 
-use Drupal\rules\Core\RulesActionBase;
+use Drupal\rules\Engine\RulesActionBase;
 use AbstractObject;
 
 /**
- * Rules action; add a relationship to an object.
+ * Rules action; remove a relationship from an object.
  *
  * @RulesAction(
- *   id = "islandora_object_add_relationship",
- *   label = @Translation("Add a relationship to an object"),
+ *   id = "islandora_object_remove_relationship",
+ *   label = @Translation("Remove a relationship from an object"),
  *   category = @Translation("Islandora"),
  *   context = {
  *     "subject" = @ContextDefinition("islandora_object",
@@ -23,13 +23,13 @@ use AbstractObject;
  *   }
  * )
  */
-class IslandoraObjectAddRelationship extends RulesActionBase {
+class ObjectRemoveRelationship extends RulesActionBase {
 
   /**
    * {@inheritdoc}
    */
   protected function doExecute(AbstractObject $subject, $pred_uri, $pred, $object, $type) {
-    $subject->relationships->add($pred_uri, $pred, $object, $type);
+    $subject->relationships->remove($pred_uri, $pred, $object, $type);
   }
 
 }

--- a/src/Plugin/RulesAction/RulesDatastreamLoad.php
+++ b/src/Plugin/RulesAction/RulesDatastreamLoad.php
@@ -25,7 +25,7 @@ use Drupal\rules\Core\RulesActionBase;
  *   }
  * )
  */
-class IslandoraRulesDatastreamLoad extends RulesActionBase {
+class RulesDatastreamLoad extends RulesActionBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesAction/RulesDatastreamLoadDomXPath.php
+++ b/src/Plugin/RulesAction/RulesDatastreamLoadDomXPath.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\RulesAction;
 
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\islandora\TypedData\IslandoraXPathTrait;
+use Drupal\islandora\TypedData\XPathTrait;
 
 /**
  * Rules action; Load a DOMXPath instance from some XML.
@@ -23,8 +23,8 @@ use Drupal\islandora\TypedData\IslandoraXPathTrait;
  *   }
  * )
  */
-class IslandoraRulesDatastreamLoadDomXPath extends RulesActionBase {
-  use IslandoraXPathTrait;
+class RulesDatastreamLoadDomXPath extends RulesActionBase {
+  use XPathTrait;
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesAction/RulesDatastreamLoadNamespaceVocab.php
+++ b/src/Plugin/RulesAction/RulesDatastreamLoadNamespaceVocab.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\RulesAction;
 
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\islandora\TypedData\IslandoraXPathTrait;
+use Drupal\islandora\TypedData\XPathTrait;
 use Drupal\taxonomy\VocabularyInterface;
 
 /**
@@ -23,8 +23,8 @@ use Drupal\taxonomy\VocabularyInterface;
  *   },
  * )
  */
-class IslandoraRulesDatastreamLoadNamespaceVocab extends RulesActionBase {
-  use IslandoraXPathTrait;
+class RulesDatastreamLoadNamespaceVocab extends RulesActionBase {
+  use XPathTrait;
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesAction/RulesDatastreamLoadXPath.php
+++ b/src/Plugin/RulesAction/RulesDatastreamLoadXPath.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\RulesAction;
 
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\islandora\TypedData\IslandoraXPathTrait;
+use Drupal\islandora\TypedData\XPathTrait;
 
 /**
  * Rules action; Load a DOMXPath instance from a datastream.
@@ -23,8 +23,8 @@ use Drupal\islandora\TypedData\IslandoraXPathTrait;
  *   }
  * )
  */
-class IslandoraRulesDatastreamLoadXPath extends RulesActionBase {
-  use IslandoraXPathTrait;
+class RulesDatastreamLoadXPath extends RulesActionBase {
+  use XPathTrait;
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesAction/RulesDatastreamQueryXPath.php
+++ b/src/Plugin/RulesAction/RulesDatastreamQueryXPath.php
@@ -35,7 +35,7 @@ use DOMXPath;
  *   }
  * )
  */
-class IslandoraRulesDatastreamQueryXPath extends RulesActionBase {
+class RulesDatastreamQueryXPath extends RulesActionBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesAction/RulesDatastreamSetXPath.php
+++ b/src/Plugin/RulesAction/RulesDatastreamSetXPath.php
@@ -3,7 +3,7 @@
 namespace Drupal\islandora\Plugin\RulesAction;
 
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\islandora\TypedData\IslandoraXPathTrait;
+use Drupal\islandora\TypedData\XPathTrait;
 
 /**
  * Rules action; Run a query against the given DOMXPath instance.
@@ -32,8 +32,8 @@ use Drupal\islandora\TypedData\IslandoraXPathTrait;
  *   }
  * )
  */
-class IslandoraRulesDatastreamSetXPath extends RulesActionBase {
-  use IslandoraXPathTrait;
+class RulesDatastreamSetXPath extends RulesActionBase {
+  use XPathTrait;
 
   /**
    * {@inheritdoc}

--- a/src/TypedData/DOMNodeDataDefinition.php
+++ b/src/TypedData/DOMNodeDataDefinition.php
@@ -7,7 +7,7 @@ use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 /**
  * DOMNode TypedData wrapper definition.
  */
-class IslandoraDOMNodeDataDefinition extends ComplexDataDefinitionBase {
+class DOMNodeDataDefinition extends ComplexDataDefinitionBase {
 
   /**
    * {@inheritdoc}

--- a/src/TypedData/DOMXPathDataDefinition.php
+++ b/src/TypedData/DOMXPathDataDefinition.php
@@ -7,7 +7,7 @@ use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 /**
  * DOMXPath TypedData wrapper definition.
  */
-class IslandoraDOMXPathDataDefinition extends ComplexDataDefinitionBase {
+class DOMXPathDataDefinition extends ComplexDataDefinitionBase {
 
   /**
    * {@inheritdoc}

--- a/src/TypedData/DatastreamDataDefinition.php
+++ b/src/TypedData/DatastreamDataDefinition.php
@@ -7,7 +7,7 @@ use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 /**
  * Tuque Datastream TypedData wrapper definition.
  */
-class IslandoraDatastreamDataDefinition extends ComplexDataDefinitionBase {
+class DatastreamDataDefinition extends ComplexDataDefinitionBase {
 
   /**
    * {@inheritdoc}

--- a/src/TypedData/ObjectDataDefinition.php
+++ b/src/TypedData/ObjectDataDefinition.php
@@ -7,7 +7,7 @@ use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 /**
  * Tuque Object TypedData wrapper definition.
  */
-class IslandoraObjectDataDefinition extends ComplexDataDefinitionBase {
+class ObjectDataDefinition extends ComplexDataDefinitionBase {
 
   /**
    * {@inheritdoc}

--- a/src/TypedData/XPathTrait.php
+++ b/src/TypedData/XPathTrait.php
@@ -11,7 +11,7 @@ use Drupal\taxonomy\VocabularyInterface;
 /**
  * DOMXPath helper methods.
  */
-trait IslandoraXPathTrait {
+trait XPathTrait {
 
   /**
    * Load XML into a DOMXPath and optionally register namespaces.


### PR DESCRIPTION
Redundant Module Prefixing

# What does this Pull Request do?

Removes redundant module prefixing from method and class names.

Restores functionality to the DSID autocomplete when adding datastreams.

  