### PR TITLE
Making print routing point at correct controller func

### DIFF
--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -71,7 +71,7 @@ islandora.printer_object:
   defaults:
     op: 'view fedora repository objects'
     _title: 'Print Object'
-    _controller: '\Drupal\islandora\Controller\DefaultController::printObject'
+    _controller: '\Drupal\islandora\Controller\DefaultController::printerObject'
   requirements:
     _custom_access: '\Drupal\islandora\Controller\DefaultController::printObjectAccess'
   options:

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -156,7 +156,7 @@ class DefaultController extends ControllerBase {
   /**
    * Islandora printer object.
    */
-  public static function printerObject(AbstractObject $object) {
+  public function printerObject(AbstractObject $object) {
     $output = [];
     $temp_arr = [];
 


### PR DESCRIPTION
There was a regression regarding printing.  It was pointing at the wrong controller function. It should now be wired correctly.