### PR TITLE
Allow for an additional path suffix to be provided for datastream downloads.

### DIFF
--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -218,11 +218,12 @@ islandora.view_datastream_view:
         type: datastream
     _islandora_token_route: TRUE
 islandora.download_datastream:
-  path: '/islandora/object/{object}/datastream/{datastream}/download'
+  path: '/islandora/object/{object}/datastream/{datastream}/download/{filename}'
   defaults:
     perms: 'view fedora repository objects'
     _title: 'Download datastream'
     _controller: '\Drupal\islandora\Controller\DefaultController::downloadDatastream'
+    filename: ''
   requirements:
     _islandora_datastream_access: 'TRUE'
   options:


### PR DESCRIPTION
# What does this Pull Request do?/What's new?

Permits an additional path component in datastream download routes, so we can continue to build them as we have.

# How should this be tested?

Check out the [associated PDF PR](https://github.com/willtp87/islandora_pdf/pull/1) which makes use of this... The "Download PDF" link should be generated correctly.

NOTE: The filename does not appear to be used by newer browsers which make use of the "Content-Disposition" header... There _is_ something of a disconnect here (in D7 also), where we have the label of the _object_ in the URL, but the header will provide the label of the _datastream_.

# Additional Notes:

* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change need changes to be made to the repository? No.
* Could this change impact execution of existing code? Unlikely.
