### PR TITLE
8.x.breadcrumbs

### DIFF
--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -94,9 +94,12 @@ function islandora_get_breadcrumbs_recursive($pid, FedoraRepository $repository,
 
   $root = \Drupal::config('islandora.settings')->get('islandora_repository_pid');
   if ($pid == $root) {
+    $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+    $islandora_links = $menu_link_manager->loadLinksByRoute('islandora.view_default_object');
+    $islandora_link = reset($islandora_links);
     return [
       Link::createFromRoute(t('Home'), '<front>'),
-      Link::createFromRoute(t('Islandora Repository'), 'islandora.view_default_object'),
+      Link::createFromRoute($islandora_link->getTitle(), 'islandora.view_default_object'),
     ];
   }
   else {

--- a/includes/breadcrumb.inc
+++ b/includes/breadcrumb.inc
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Link;
 
+use Drupal\islandora\Tuque\IslandoraFedoraRepository;
+
 /**
  * Get an array of links to be passed to drupal_set_breadcrumb().
  *
@@ -92,26 +94,12 @@ function islandora_get_breadcrumbs_recursive($pid, FedoraRepository $repository,
 
   $root = \Drupal::config('islandora.settings')->get('islandora_repository_pid');
   if ($pid == $root) {
-    $title = 'Islandora Repository';
-    $mlid = db_select('menu_links', 'ml')
-      ->condition('ml.link_path', 'islandora')
-      ->fields('ml', ['mlid'])
-      ->execute()
-      ->fetchField();
-
-    if ($mlid) {
-      $link = menu_link_load($mlid);
-      $title = (isset($link['title']) ? $link['title'] : $title);
-    }
-
     return [
       Link::createFromRoute(t('Home'), '<front>'),
-      Link::createFromRoute($title, 'islandora.view_default_object'),
+      Link::createFromRoute(t('Islandora Repository'), 'islandora.view_default_object'),
     ];
-
   }
   else {
-
     $query = <<<EOQ
     PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
     PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
@@ -141,12 +129,12 @@ EOQ;
     $collection_predicate_filters = array_map($same_term_map, $breadcrumb_predicates);
     $query_filters[] = implode(' || ', $collection_predicate_filters);
     $query_order = "ORDER BY DESC(?label)";
-    $query = format_string($query, [
+    $query = strtr($query, [
       '!optionals' => !empty($query_optionals) ? ('OPTIONAL {{' . implode('} UNION {', $query_optionals) . '}}') : '',
       '!filters' => implode(' ', array_map($filter_map, $query_filters)),
       '!order' => $query_order,
     ]);
-    $query = format_string($query, [
+    $query = strtr($query, [
       '!pid' => $pid,
     ]);
     $results = $repository->ri->sparqlQuery($query, 'unlimited');

--- a/islandora.links.menu.yml
+++ b/islandora.links.menu.yml
@@ -37,19 +37,8 @@ islandora.view_default_object_0:
   route_name: islandora.view_default_object_0
   title: 'Browse Objects'
   parent: islandora.view_default_object
-islandora.view_object:
-  route_name: islandora.view_object
-  parent: islandora.view_default_object
-islandora.manage_overview_object:
-  route_name: islandora.manage_overview_object
-  parent: islandora.view_object
-  title: 'Manage'
 islandora.deleted_objects_manage_form:
   route_name: islandora.deleted_objects_manage_form
   parent: islandora.admin_config
   title: 'Manage Deleted Objects'
   description: 'Restore or permanently remove objects with Deleted status'
-islandora.object_properties_form:
-  route_name: islandora.object_properties_form
-  parent: islandora.manage_overview_object
-  title: 'Properties'

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -21,4 +21,8 @@ services:
     class: Drupal\islandora\Authentication\Provider\TokenAuth
     arguments: ['@config.factory', '@entity.manager']
     tags:
-      - {name: authentication_provider, provider_id: islandora_auth_token, global: TRUE, priority: 1}
+      - { name: authentication_provider, provider_id: islandora_auth_token, global: TRUE, priority: 1 }
+  islandora.breadcrumb:
+    class: Drupal\islandora\Breadcrumb\ObjectBreadcrumbs
+    tags:
+      - { name: breadcrumb_builder, priority: 100 }

--- a/src/Breadcrumb/ObjectBreadcrumbs.php
+++ b/src/Breadcrumb/ObjectBreadcrumbs.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\islandora\Breadcrumb;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Provides breadcrumbs for Islandora objects.
+ */
+class ObjectBreadcrumbs implements BreadcrumbBuilderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $path = $route_match->getRouteObject()->getPath();
+    if (strpos($path, '/islandora/object/') === 0) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    module_load_include('inc', 'islandora', 'includes/breadcrumb');
+    $object_breadcrumbs = islandora_get_breadcrumbs($route_match->getParameter('object'));
+    $breadcrumb = new Breadcrumb();
+
+    // Add a link to the homepage as our first crumb.
+    foreach ($object_breadcrumbs as $object_breadcrumb) {
+      $breadcrumb->addLink($object_breadcrumb);
+    }
+
+    $breadcrumb->addCacheContexts(['route']);
+    return $breadcrumb;
+  }
+
+}

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -97,7 +97,6 @@ class DefaultController extends ControllerBase {
    */
   public function drupalTitle(AbstractObject $object) {
     module_load_include('inc', 'islandora', 'includes/breadcrumb');
-    // drupal_set_breadcrumb(islandora_get_breadcrumbs($object));
     return $object->label;
   }
 

--- a/src/Form/RepositoryAdmin.php
+++ b/src/Form/RepositoryAdmin.php
@@ -213,7 +213,7 @@ class RepositoryAdmin extends ModuleHandlerAdminForm {
       ->set('islandora_defer_derivatives_on_ingest', $form_state->getValue('islandora_defer_derivatives_on_ingest'))
       ->set('islandora_show_print_option', $form_state->getValue('islandora_show_print_option'))
       ->set('islandora_render_context_ingeststep', $form_state->getValue('islandora_render_context_ingeststep'))
-      ->set('islandora_breadcrumbs_backends', $form_state->getValue('islandora_breadcrumbs_backend'))
+      ->set('islandora_breadcrumbs_backends', $form_state->getValue('islandora_breadcrumbs_backends'))
       ->set('islandora_risearch_use_itql_when_necessary', $form_state->getValue('islandora_risearch_use_itql_when_necessary'))
       ->set('islandora_require_obj_upload', $form_state->getValue('islandora_require_obj_upload'))
       ->set('islandora_namespace_restriction_enforced', $form_state->getValue('islandora_namespace_restriction_enforced'))


### PR DESCRIPTION
Ports object hierarchy breadcrumbs to D8.

* [issue](https://github.com/discoverygarden/islandora/issues/13)

# What does this Pull Request do?

Implements a service for breadcrumbs and removes some disruptive menu entries.

# How should this be tested?

Go to a nested object and see that the object hierarchy is reflected in the breadcrumbs.
Try to edit the tools menu and see that it does not white screen.