### PR TITLE
Ingest working in Safari

### DIFF
--- a/js/spinner.js
+++ b/js/spinner.js
@@ -21,6 +21,10 @@
           }
         });
       });
+
+      // Remove Drupal core handler that blocks our second submit of forms.
+      $('body').off('submit.singleSubmit');
+
       $.each(settings.spinner, function (base, value) {
         var id = '#' + base,
           message = $('<div/>').text(settings.spinner[base].message);
@@ -34,6 +38,7 @@
                 return;
               }
               if ($(this).data('clicked').is(id) && $(this).data('submitted') === undefined) {
+                event.preventDefault();
                 // Prevent this from being entered a second time.
                 $(this).data('submitted', true);
                 // Add Message.
@@ -49,8 +54,13 @@
                   $(':submit').attr('disabled', 'disabled');
                 }
                 setTimeout(function () {
-                  $(id).removeAttr('disabled');
-                  $(id).click();
+                  // Allow for the button to be clicked, then click it then
+                  // prevent the default behaviour.
+                  $(id).removeAttr('disabled')
+                    .click()
+                    .click(function (event) {
+                      event.preventDefault();
+                    });
                 }, 500);
               }
               return true;


### PR DESCRIPTION
Safari Spinner JS

# What does this Pull Request do?

Fixes a bug where ingesting using Safari was not working.

# What's new?

Re-introduces some JS default action handling and removes a Drupal core event handler that was preventing it from working as intended.

# How should this be tested?

Ingest using Safari, notice that you can.
