### PR TITLE
Handle warning when object is locked down

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -563,7 +563,7 @@ function islandora_tokened_datastream_load($datastream_id, array $map) {
  *
  * @return FedoraDatastream
  *   If the given datastream ID exists then this returns a FedoraDatastream
- *   object, otherwise it returns NULL which triggers drupal_page_not_found().
+ *   object, otherwise it returns NULL.
  */
 function islandora_datastream_load($datastream_id, $object_id) {
   $object = is_object($object_id) ? $object_id : islandora_object_load($object_id);
@@ -855,7 +855,6 @@ function islandora_datastream_access($op, $datastream, $user = NULL) {
       !in_array(FALSE, $datastream_results, TRUE) && in_array(TRUE, $datastream_results, TRUE)
     );
   }
-
   return $cache[$op][$datastream->parent->id][$datastream->id][$user->id()];
 }
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -104,12 +104,9 @@ class DefaultController extends ControllerBase {
   /**
    * View islandora object.
    */
-  public function viewObject($object, Request $currentRequest) {
+  public function viewObject(AbstractObject $object, Request $currentRequest) {
     module_load_include('inc', 'islandora', 'includes/breadcrumb');
     module_load_include('inc', 'islandora', 'includes/utilities');
-    if (!$object) {
-      throw new NotFoundHttpException();
-    }
     // XXX: This seems so very dumb but given how empty slugs don't play nice
     // in Drupal as defaults this needs to be the case. If it's possible to get
     // around this by making the empty slug route in YAML or a custom Routing
@@ -248,7 +245,6 @@ class DefaultController extends ControllerBase {
   public function viewDatastream(AbstractDatastream $datastream, $download = FALSE, $version = NULL) {
     module_load_include('inc', 'islandora', 'includes/mimetype.utils');
     module_load_include('inc', 'islandora', 'includes/datastream');
-
     if ($version !== NULL) {
       if (isset($datastream[$version])) {
         $datastream = $datastream[$version];

--- a/src/ParamConverter/DatastreamParamConverter.php
+++ b/src/ParamConverter/DatastreamParamConverter.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora\ParamConverter;
 
 use Drupal\Core\ParamConverter\ParamConverterInterface;
+use Drupal\Core\ParamConverter\ParamNotConvertedException;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -26,7 +27,14 @@ class DatastreamParamConverter implements ParamConverterInterface {
     // in Drupal as defaults this needs to be the case. If it's possible to get
     // around this by making the empty slug route in YAML or a custom Routing
     // object we can remove this.
-    return islandora_datastream_load($value, $defaults['object']->id);
+    $datastream = islandora_datastream_load($value, $defaults['object']->id);
+    if ($datastream) {
+      // Success.
+      return $datastream;
+    }
+    else {
+      throw new ParamNotConvertedException();
+    }
   }
 
   /**

--- a/src/ParamConverter/DatastreamParamConverter.php
+++ b/src/ParamConverter/DatastreamParamConverter.php
@@ -14,6 +14,14 @@ class DatastreamParamConverter implements ParamConverterInterface {
    * Datastream parameter converter method.
    */
   public function convert($value, $definition, $name, array $defaults) {
+    if ($defaults['object'] === FALSE) {
+      // Return for 404.
+      return NULL;
+    }
+    elseif ($defaults['object'] === NULL) {
+      // Let the access layer take care of it.
+      return FALSE;
+    }
     // XXX: This seems so very dumb but given how empty slugs don't play nice
     // in Drupal as defaults this needs to be the case. If it's possible to get
     // around this by making the empty slug route in YAML or a custom Routing

--- a/src/ParamConverter/ObjectParamConverter.php
+++ b/src/ParamConverter/ObjectParamConverter.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora\ParamConverter;
 
 use Drupal\Core\ParamConverter\ParamConverterInterface;
+use Drupal\Core\ParamConverter\ParamNotConvertedException;
 use Drupal\Core\Config\ConfigFactoryInterface;
 
 use Symfony\Component\Routing\Route;
@@ -36,8 +37,7 @@ class ObjectParamConverter implements ParamConverterInterface {
       return $object;
     }
     elseif ($object === FALSE) {
-      // Return for 404.
-      return NULL;
+      throw new ParamNotConvertedException();
     }
     else {
       // Let the access layer take care of it.


### PR DESCRIPTION
Prevents an error when viewing a datastream on an object when the object is locked down. This should also have 404/403 sorted out for objects and datastreams.