### PR TITLE
Making cache clear work for compound child reordering

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -1083,7 +1083,7 @@ function islandora_conditionally_clear_cache() {
 
   $functions = [
     // Object changes in response to a form.
-    'form_execute_handlers' => 'islandora_cache_clear_all',
+    'executesubmithandlers' => 'islandora_cache_clear_all',
     // Object changes in response to a batch. Note that this will not match on
     // a drush batch, as drush uses a different set of functions to run
     // batches. We intentionally do not clear batches in response to drush
@@ -1111,7 +1111,6 @@ function islandora_cache_clear_all() {
   if (isset($clear)) {
     $clear =& drupal_static(__FUNCTION__, FALSE);
   }
-
   if (!$clear) {
     $clear = TRUE;
     drupal_register_shutdown_function('islandora_shutdown_cache_clear_all');
@@ -1125,6 +1124,7 @@ function islandora_cache_clear_all() {
  */
 function islandora_shutdown_cache_clear_all() {
   \Drupal::cache('render')->deleteAll();
+  \Drupal::cache('dynamic_page_cache')->deleteAll();
 }
 
 /**
@@ -1133,7 +1133,6 @@ function islandora_shutdown_cache_clear_all() {
 function islandora_schedule_cache_clear_for_batch() {
   $batch =& batch_get();
   static $scheduled;
-
   $scheduled = isset($scheduled) || isset($batch['islandora_cache_clear_scheduled']);
 
   if ($scheduled || !isset($batch['id'])) {
@@ -1141,7 +1140,6 @@ function islandora_schedule_cache_clear_for_batch() {
     // batch is not running.
     return;
   }
-
   $clear_batch = [
     'operations' => [
       ['islandora_cache_clear_all', []],


### PR DESCRIPTION
# What does this Pull Request do?

When reordering compound children as a non-administrative user, the object view page should display according to the new order.

# What's new?
Clearing the 'dynamic_page_cache' bin when a batch runs.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem

1. Enable [Compound module](https://github.com/discoverygarden/islandora_compound_object).

1. Set up a compound object with children.

1. Make a user with Islandora permissions and Islandora compound object permissions.

1. Login as the user created in the previous step.

1. Go to the Manage/Compound page for the compound object that was created in step 2.

1. Reorder the children so that a new child is the first child, and save that.

1. Go to the view page for the compound object and see that the old first child is the one being shown.

* Test that the Pull Request does what is intended.

1. Pull down this code.

1. Do the steps to reproduce the bug.

1. See that the first child on the object view page is now updated.