### PR TITLE
Make the viewing of the objects dependent on Islandora's configuration.

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -142,6 +142,9 @@ class DefaultController extends ControllerBase {
 
     arsort($output);
     $this->moduleHandler()->alter($hooks, $object, $output);
+
+    $this->renderer->addCacheableDependency($output, $this->config('islandora.settings'));
+
     return $output;
   }
 


### PR DESCRIPTION
... Changing in islandora.settings will cause the cache entries to be
invalidated, so effects are immediately visible.