### PR TITLE
Update php version for D8

### DIFF
--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -6,5 +6,5 @@ dependencies:
   - drupal:image
   - drupal:file
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)