### PR TITLE
Renderable arrays for metadata

### DIFF
--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -122,15 +122,7 @@ function islandora_metadata_display_callback(AbstractObject $object, $print = FA
 }
 
 /**
- * Metadata display callback for rendering Dublin Core metadata.
- *
- * @param AbstractObject $object
- *   An AbstractObject representing an object within Fedora.
- * @param bool $print
- *   Whether the display is being printed or not.
- *
- * @return array
- *   Renderable array representing the rendered metadata from Dublin Core.
+ * Implements callback_islandora_metadata_display() for Dublin Core.
  */
 function islandora_metadata_display_renderable_callback(AbstractObject $object, $print = FALSE) {
   return [
@@ -141,13 +133,7 @@ function islandora_metadata_display_renderable_callback(AbstractObject $object, 
 }
 
 /**
- * Metadata description callback for rendering Dublin Core description.
- *
- * @param AbstractObject $islandora_object
- *   An AbstractObject representing an object within Fedora.
- *
- * @return array
- *   Render array representing the rendered metadata from Dublin Core.
+ * Implements callback_islandora_description_display() for Dublin Core.
  */
 function islandora_metadata_description_callback(AbstractObject $islandora_object) {
   return [

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -90,7 +90,7 @@ function islandora_retrieve_renderable_description(AbstractObject $object) {
   $viewers = \Drupal::moduleHandler()->invokeAll('islandora_metadata_display_info');
   $config = \Drupal::config('islandora.settings');
   $viewer = $config->get('islandora_metadata_display');
-  $markup = '';
+  $markup = [];
   if (isset($viewers[$viewer]['description callback'])) {
     $hooks = islandora_build_hook_list(ISLANDORA_METADATA_OBJECT_DESCRIPTION_ALTER, $object->models);
     \Drupal::moduleHandler()->alter($hooks, $object);

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -16,15 +16,15 @@
  * @return string
  *   Markup to be rendered for display on Islandora object pages.
  *
- * @deprecated _islandora_retrieve_metadata_markup() should be preferred.
+ * @deprecated islandora_retrieve_renderable_metadata() should be preferred.
  */
 function islandora_retrieve_metadata_markup(AbstractObject $object, $print = FALSE) {
-  $markup = _islandora_retrieve_metadata_markup($object, $print);
+  $markup = islandora_retrieve_renderable_metadata($object, $print);
   return \Drupal::service('renderer')->render($markup);
 }
 
 /**
- * Retrieves the metadata display markup for an Islandora object.
+ * Retrieves the metadata display for an Islandora object.
  *
  * @param AbstractObject $object
  *   An AbstractObject representing an object within Fedora.
@@ -34,7 +34,7 @@ function islandora_retrieve_metadata_markup(AbstractObject $object, $print = FAL
  * @return array
  *   Renderable array to be rendered for display on Islandora object pages.
  */
-function _islandora_retrieve_metadata_markup(AbstractObject $object, $print = FALSE) {
+function islandora_retrieve_renderable_metadata(AbstractObject $object, $print = FALSE) {
   $viewers = \Drupal::moduleHandler()->invokeAll('islandora_metadata_display_info');
   $config = \Drupal::config('islandora.settings');
   $viewer = $config->get('islandora_metadata_display');
@@ -70,10 +70,10 @@ function _islandora_retrieve_metadata_markup(AbstractObject $object, $print = FA
  * @return string
  *   Markup to be rendered for description on Islandora object pages.
  *
- * @deprecated _islandora_retrieve_description_markup() should be preferred.
+ * @deprecated islandora_retrieve_renderable_description() should be preferred.
  */
 function islandora_retrieve_description_markup(AbstractObject $object) {
-  $markup = _islandora_retrieve_description_markup($object);
+  $markup = islandora_retrieve_renderable_description($object);
   return \Drupal::service('renderer')->render($markup);
 }
 
@@ -86,7 +86,7 @@ function islandora_retrieve_description_markup(AbstractObject $object) {
  * @return array
  *   Markup to be rendered for description on Islandora object pages.
  */
-function _islandora_retrieve_description_markup(AbstractObject $object) {
+function islandora_retrieve_renderable_description(AbstractObject $object) {
   $viewers = \Drupal::moduleHandler()->invokeAll('islandora_metadata_display_info');
   $config = \Drupal::config('islandora.settings');
   $viewer = $config->get('islandora_metadata_display');
@@ -117,7 +117,7 @@ function _islandora_retrieve_description_markup(AbstractObject $object) {
  *   Markup representing the rendered metadata from Dublin Core.
  */
 function islandora_metadata_display_callback(AbstractObject $object, $print = FALSE) {
-  $render_array = _islandora_metadata_display_callback($object, $print);
+  $render_array = islandora_metadata_display_renderable_callback($object, $print);
   return \Drupal::service('renderer')->render($render_array);
 }
 
@@ -132,7 +132,7 @@ function islandora_metadata_display_callback(AbstractObject $object, $print = FA
  * @return array
  *   Renderable array representing the rendered metadata from Dublin Core.
  */
-function _islandora_metadata_display_callback(AbstractObject $object, $print = FALSE) {
+function islandora_metadata_display_renderable_callback(AbstractObject $object, $print = FALSE) {
   return [
     '#theme' => 'islandora_dublin_core_display',
     '#islandora_object' => $object,

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -47,7 +47,7 @@ function islandora_retrieve_renderable_metadata(AbstractObject $object, $print =
     // The callback doesn't have any markup provided for this particular object,
     // default back to the dublin_core display.
     if ($markup === FALSE) {
-      $markup = _islandora_metadata_display_callback($object, $print);
+      $markup = islandora_metadata_display_renderable_callback($object, $print);
     }
     elseif (is_string($markup) || (is_object($markup) && is_callable([$markup, '__toString']))) {
       $markup = [

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -15,11 +15,30 @@
  *
  * @return string
  *   Markup to be rendered for display on Islandora object pages.
+ *
+ * @deprecated _islandora_retrieve_metadata_markup() should be preferred.
  */
 function islandora_retrieve_metadata_markup(AbstractObject $object, $print = FALSE) {
+  $markup = _islandora_retrieve_metadata_markup($object, $print);
+  return \Drupal::service('renderer')->render($markup);
+}
+
+/**
+ * Retrieves the metadata display markup for an Islandora object.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing an object within Fedora.
+ * @param bool $print
+ *   Whether the object is being printed.
+ *
+ * @return array
+ *   Renderable array to be rendered for display on Islandora object pages.
+ */
+function _islandora_retrieve_metadata_markup(AbstractObject $object, $print = FALSE) {
   $viewers = \Drupal::moduleHandler()->invokeAll('islandora_metadata_display_info');
-  $viewer = \Drupal::config('islandora.settings')->get('islandora_metadata_display');
-  $markup = '';
+  $config = \Drupal::config('islandora.settings');
+  $viewer = $config->get('islandora_metadata_display');
+  $markup = [];
   if (isset($viewers[$viewer]['metadata callback'])) {
     module_load_include('inc', 'islandora', 'includes/utilities');
     $hooks = islandora_build_hook_list(ISLANDORA_METADATA_OBJECT_ALTER, $object->models);
@@ -28,9 +47,17 @@ function islandora_retrieve_metadata_markup(AbstractObject $object, $print = FAL
     // The callback doesn't have any markup provided for this particular object,
     // default back to the dublin_core display.
     if ($markup === FALSE) {
-      $markup = call_user_func($viewers['dublin_core']['metadata callback'], $object, $print);
+      $markup = _islandora_metadata_display_callback($object, $print);
+    }
+    elseif (is_string($markup) || (is_object($markup) && is_callable([$markup, '__toString']))) {
+      $markup = [
+        '#markup' => $markup,
+      ];
     }
   }
+
+  \Drupal::service('renderer')->addCacheableDependency($markup, $config);
+
   return $markup;
 }
 
@@ -42,10 +69,27 @@ function islandora_retrieve_metadata_markup(AbstractObject $object, $print = FAL
  *
  * @return string
  *   Markup to be rendered for description on Islandora object pages.
+ *
+ * @deprecated _islandora_retrieve_description_markup() should be preferred.
  */
 function islandora_retrieve_description_markup(AbstractObject $object) {
+  $markup = _islandora_retrieve_description_markup($object);
+  return \Drupal::service('renderer')->render($markup);
+}
+
+/**
+ * Retrieves the metadata display description for an Islandora object.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing an object within Fedora.
+ *
+ * @return array
+ *   Markup to be rendered for description on Islandora object pages.
+ */
+function _islandora_retrieve_description_markup(AbstractObject $object) {
   $viewers = \Drupal::moduleHandler()->invokeAll('islandora_metadata_display_info');
-  $viewer = \Drupal::config('islandora.settings')->get('islandora_metadata_display');
+  $config = \Drupal::config('islandora.settings');
+  $viewer = $config->get('islandora_metadata_display');
   $markup = '';
   if (isset($viewers[$viewer]['description callback'])) {
     $hooks = islandora_build_hook_list(ISLANDORA_METADATA_OBJECT_DESCRIPTION_ALTER, $object->models);
@@ -57,7 +101,8 @@ function islandora_retrieve_description_markup(AbstractObject $object) {
       $markup = call_user_func($viewers['dublin_core']['description callback'], $object);
     }
   }
-  return \Drupal::service('renderer')->render($markup);
+  \Drupal::service('renderer')->addCacheableDependency($markup, $config);
+  return $markup;
 }
 
 /**
@@ -72,12 +117,27 @@ function islandora_retrieve_description_markup(AbstractObject $object) {
  *   Markup representing the rendered metadata from Dublin Core.
  */
 function islandora_metadata_display_callback(AbstractObject $object, $print = FALSE) {
-  $render_array = [
+  $render_array = _islandora_metadata_display_callback($object, $print);
+  return \Drupal::service('renderer')->render($render_array);
+}
+
+/**
+ * Metadata display callback for rendering Dublin Core metadata.
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing an object within Fedora.
+ * @param bool $print
+ *   Whether the display is being printed or not.
+ *
+ * @return array
+ *   Renderable array representing the rendered metadata from Dublin Core.
+ */
+function _islandora_metadata_display_callback(AbstractObject $object, $print = FALSE) {
+  return [
     '#theme' => 'islandora_dublin_core_display',
     '#islandora_object' => $object,
     '#print' => $print,
   ];
-  return \Drupal::service('renderer')->render($render_array);
 }
 
 /**
@@ -86,8 +146,8 @@ function islandora_metadata_display_callback(AbstractObject $object, $print = FA
  * @param AbstractObject $islandora_object
  *   An AbstractObject representing an object within Fedora.
  *
- * @return string
- *   Markup representing the rendered metadata from Dublin Core.
+ * @return array
+ *   Render array representing the rendered metadata from Dublin Core.
  */
 function islandora_metadata_description_callback(AbstractObject $islandora_object) {
   return [

--- a/includes/metadata.inc
+++ b/includes/metadata.inc
@@ -47,7 +47,7 @@ function islandora_retrieve_renderable_metadata(AbstractObject $object, $print =
     // The callback doesn't have any markup provided for this particular object,
     // default back to the dublin_core display.
     if ($markup === FALSE) {
-      $markup = islandora_metadata_display_renderable_callback($object, $print);
+      $markup = call_user_func($viewers['dublin_core']['metadata callback'], $object, $print);
     }
     elseif (is_string($markup) || (is_object($markup) && is_callable([$markup, '__toString']))) {
       $markup = [

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -797,16 +797,14 @@ function hook_islandora_breadcrumbs_alter(array &$breadcrumbs, $context, $object
  *
  * @return array
  *   An associative array where the values are the following:
- *   -label: Human readable display label for selection.
- *   -description: A description of what the metadata display viewer does.
- *   -metadata callback: A callable function that provides the markup to be
- *    passed  off to the template files. Returns markup or FALSE if the viewer
- *    wishes to default back to the Dublin Core display for the current object.
- *   -description callback: A callable function that provides the markup to be
- *    passed for the description. Returns markup or FALSE if the viewer
- *    wishes to default back to the Dublin Core display for the current object.
- *   -configuration (Optional): A route name to the administration page for the
- *    metadata display.
+ *   - label: Human readable display label for selection.
+ *   - description: A description of what the metadata display viewer does.
+ *   - metadata callback: A callable implementing
+ *     callback_islandora_metadata_display().
+ *   - description callback: A callable implementing
+ *     callback_islandora_description_display().
+ *   - configuration (Optional): A route name to the administration page for the
+ *     metadata display.
  *
  * @see islandora_retrieve_metadata_markup()
  */
@@ -815,11 +813,41 @@ function hook_islandora_metadata_display_info() {
     'hookable_displays_yay' => [
       'label' => t('Hookable display yay!'),
       'description' => t('This is purely an example of how to implement this.'),
-      'metadata callback' => 'hookable_displays_some_function_that_returns_metadata_markup',
-      'description callback' => 'hookable_displays_some_function_that_returns_description_markup',
+      'metadata callback' => 'callback_islandora_metadata_display',
+      'description callback' => 'callback_islandora_description_display',
       'configuration' => 'islandora.sample_route',
     ],
   ];
+}
+
+/**
+ * Metadata display callback.
+ *
+ * @param AbstractObject $object
+ *   The object for which to render metadata.
+ * @param bool $print
+ *   A flag indicatig if the metadata is being output for printing.
+ *
+ * @return array|bool
+ *   A renderable array representing the metadata to display; alternatively,
+ *   boolean FALSE may be returned to force the Dublin Core display to be shown.
+ */
+function callback_islandora_metadata_display(AbstractObject $object, $print = FALSE) {
+
+}
+
+/**
+ * Description display callback.
+ *
+ * @param AbstractObject $object
+ *   The object for which to render a description.
+ *
+ * @return array|bool
+ *   A renderable array representing the description to display; alternatively,
+ *   boolean FALSE may be returned to force the Dublin Core display to be shown.
+ */
+function callback_islandora_description_display(AbstractObject $object) {
+
 }
 
 /**

--- a/islandora.api.php
+++ b/islandora.api.php
@@ -833,7 +833,7 @@ function hook_islandora_metadata_display_info() {
  *   boolean FALSE may be returned to force the Dublin Core display to be shown.
  */
 function callback_islandora_metadata_display(AbstractObject $object, $print = FALSE) {
-
+  return FALSE;
 }
 
 /**
@@ -847,7 +847,7 @@ function callback_islandora_metadata_display(AbstractObject $object, $print = FA
  *   boolean FALSE may be returned to force the Dublin Core display to be shown.
  */
 function callback_islandora_description_display(AbstractObject $object) {
-
+  return FALSE;
 }
 
 /**

--- a/islandora.module
+++ b/islandora.module
@@ -983,7 +983,7 @@ function islandora_islandora_metadata_display_info() {
     'dublin_core' => [
       'label' => t('Dublin Core'),
       'description' => t('Dublin Core metadata'),
-      'metadata callback' => 'islandora_metadata_display_callback',
+      'metadata callback' => 'islandora_metadata_display_renderable_callback',
       'description callback' => 'islandora_metadata_description_callback',
     ],
   ];


### PR DESCRIPTION
Need 'em, in order to appropriately bubble cache metadata.