### PR TITLE
Drush 9 command compatibility

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  islandora.commands:
+    class: \Drupal\islandora\Commands\IslandoraCommands
+    tags:
+      - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -4,18 +4,18 @@ services:
     arguments:
       - '@module_handler'
     tags:
-      - { name: drush.command }
+      - name: drush.command
   islandora.command.user_wrapper:
     class: \Drupal\islandora\Commands\UserWrapperCommands
     arguments:
       - '@account_switcher'
       - '@entity_type.manager'
     tags:
-      - { name: drush.command }
+      - name: drush.command
   islandora.command.validators:
     class: \Drupal\islandora\Commands\ValidatorCommands
     tags:
-      - { name: drush.command }
+      - name: drush.command
   islandora.command.user_wrapping_alterer:
     class: \Drupal\islandora\Commands\UserWrappingAlterer
     tags:

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -5,3 +5,14 @@ services:
       - '@module_handler'
     tags:
       - { name: drush.command }
+  islandora.command.user_wrapper:
+    class: \Drupal\islandora\Commands\UserWrapperCommands
+    arguments:
+      - '@account_switcher'
+      - '@entity_type.manager'
+    tags:
+      - { name: drush.command }
+  islandora.command.validators:
+    class: \Drupal\islandora\Commands\ValidatorCommands
+    tags:
+      - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,5 +1,7 @@
 services:
   islandora.commands:
     class: \Drupal\islandora\Commands\IslandoraCommands
+    arguments:
+      - '@module_handler'
     tags:
       - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -16,3 +16,9 @@ services:
     class: \Drupal\islandora\Commands\ValidatorCommands
     tags:
       - { name: drush.command }
+  islandora.command.user_wrapping_alterer:
+    class: \Drupal\islandora\Commands\UserWrappingAlterer
+    tags:
+      - name: drush.command_info_alterer
+    arguments:
+      - '@logger.factory'

--- a/islandora.module
+++ b/islandora.module
@@ -1221,3 +1221,63 @@ function islandora_islandora_solution_pack_child_relationships($cmodels) {
   // exist when the hook is called, even if no module responds.
   return ['predicate' => [], 'prefix' => []];
 }
+
+/**
+ * Implements hook_batch_alter().
+ */
+function islandora_batch_alter(&$batch) {
+  // XXX: Batches performed under Drush 9 do not inherit the user of the
+  // caller, and Drush 9's "process.manager" service is not easily
+  // overridable so as to be able to override... SO: Let's wrap all batch
+  // operations passing through the CLI if they have been submitted as an
+  // authenticated user, to make them run as said authenticated user.
+  // Somewhat associated with Drush 9's whole dropping-support-for-the-"--user"
+  // -argument business...
+  // @see https://github.com/drush-ops/drush/issues/3396
+  if (PHP_SAPI !== 'cli') {
+    return;
+  }
+
+  $user = \Drupal::currentUser();
+  if (!$user->isAuthenticated()) {
+    return;
+  }
+
+  $wrap_op = function ($op) use ($user) {
+    list($func, $args) = $op;
+    return $func !== '_islandora_user_wrapped_batch_op' ?
+      [
+        '_islandora_user_wrapped_batch_op',
+        [
+          $user->id(),
+          $op,
+        ],
+      ] :
+      $op;
+  };
+
+  foreach ($batch['sets'] as &$set) {
+    $set['operations'] = array_map($wrap_op, $set['operations']);
+  }
+  // XXX: Clean up the reference.
+  unset($set);
+}
+
+/**
+ * Wrap batch op with user.
+ */
+function _islandora_user_wrapped_batch_op($id, $info, &$context) {
+
+  $switcher = \Drupal::service('account_switcher');
+  try {
+    $user = \Drupal::service('entity_type.manager')->getStorage('user')->load($id);
+    $switcher->switchTo($user);
+
+    list($op, $args) = $info;
+    return call_user_func_array($op, array_merge($args, [&$context]));
+  }
+  finally {
+    $switcher->switchBack();
+  }
+
+}

--- a/islandora.module
+++ b/islandora.module
@@ -1244,7 +1244,7 @@ function islandora_batch_alter(&$batch) {
   }
 
   $wrap_op = function ($op) use ($user) {
-    list($func, $args) = $op;
+    $func = reset($op);
     return $func !== '_islandora_user_wrapped_batch_op' ?
       [
         '_islandora_user_wrapped_batch_op',

--- a/islandora.module
+++ b/islandora.module
@@ -1238,22 +1238,34 @@ function islandora_batch_alter(&$batch) {
     return;
   }
 
+  $logger = \Drupal::logger('islandora');
   $user = \Drupal::currentUser();
   if (!$user->isAuthenticated()) {
+    $logger->debug('Non-authenticated batch; skipping @wrapper wrapping...', [
+      '@wrapper' => '_islandora_user_wrapped_batch_op',
+    ]);
     return;
   }
 
-  $wrap_op = function ($op) use ($user) {
+  $wrap_op = function ($op) use ($user, $logger) {
     $func = reset($op);
-    return $func !== '_islandora_user_wrapped_batch_op' ?
-      [
+    if ($func !== '_islandora_user_wrapped_batch_op') {
+      $logger->debug('Wrapping @func with @wrapper to maintain the user (@uid).', [
+        '@func' => $func,
+        '@wrapper' => '_islandora_user_wrapped_batch_op',
+        '@uid' => $user->id(),
+      ]);
+      return [
         '_islandora_user_wrapped_batch_op',
         [
           $user->id(),
           $op,
         ],
-      ] :
-      $op;
+      ];
+    }
+    else {
+      return $op;
+    }
   };
 
   foreach ($batch['sets'] as &$set) {

--- a/src/Commands/AbstractPluginAcquisition.php
+++ b/src/Commands/AbstractPluginAcquisition.php
@@ -100,7 +100,7 @@ abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAl
   /**
    * Download and install the plugin.
    */
-  public function plugin($path = NULL) {
+  protected function plugin($path = NULL) {
     if (!$path) {
       $this->logger()->debug('Acquiring default installation path.');
       $path = implode('/', [

--- a/src/Commands/AbstractPluginAcquisition.php
+++ b/src/Commands/AbstractPluginAcquisition.php
@@ -74,7 +74,17 @@ abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAl
   abstract protected function getDescriptor();
 
   /**
-   * Get the "original" installation dir.
+   * Get the directory into which to unpack the plugin.
+   *
+   * @return string
+   *   The directory into which the plugin will initially be unpacked.
+   */
+  protected function getUnpackDir($path) {
+    return $this->getInstallDir($path);
+  }
+
+  /**
+   * Get the original installation dir; possibly inside of the "unpack" dir.
    *
    * @param string $path
    *   The containing directory where it might have been installed.
@@ -84,7 +94,7 @@ abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAl
    *   installed.
    */
   protected function getOriginalDir($path) {
-    return $this->getInstallDir($path);
+    return $this->getUnpackDir($path);
   }
 
   /**
@@ -125,7 +135,7 @@ abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAl
       // Decompress the archive.
       $this->archiveManager
         ->getInstance(['filepath' => $filepath])
-        ->extract($install_dir);
+        ->extract($this->getUnpackDir($path));
 
       // Change the directory name if needed.
       if ($original_dir != $install_dir) {

--- a/src/Commands/AbstractPluginAcquisition.php
+++ b/src/Commands/AbstractPluginAcquisition.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Drush\Commands\DrushCommands;
+use Drush\SiteAlias\SiteAliasManagerAwareInterface;
+use Drush\SiteAlias\SiteAliasManagerAwareTrait;
+use Drupal\Core\File\FileSystemInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Drupal\Component\Plugin\PluginManagerInterface;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAliasManagerAwareInterface {
+
+  use SiteAliasManagerAwareTrait;
+
+  /**
+   * Drupal's filesystem.
+   *
+   * @var Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Archive plugin manager.
+   *
+   * @var Drupal\Core\Archiver\ArchiverManager
+   */
+  protected $archiveManager;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(FileSystemInterface $file_system, PluginManagerInterface $archive_manager) {
+    $this->fileSystem = $file_system;
+    $this->archiveManager = $archive_manager;
+  }
+
+  /**
+   * Get the URI from which to acquire the plugin.
+   *
+   * @return string
+   *   The URI from which to acquire the plugin.
+   */
+  abstract protected function getDownloadUri();
+
+  /**
+   * Get the path into which the plugin should be installed.
+   *
+   * @param string $path
+   *   The containing directory where it should be installed.
+   *
+   * @return string
+   *   The directory inside of $path into which to install the plugin.
+   */
+  abstract protected function getInstallDir($path);
+
+  /**
+   * Get a descriptive string for this plugin.
+   *
+   * @return string
+   *   A descriptive string for this plugin.
+   */
+  abstract protected function getDescriptor();
+
+  /**
+   * Get the "original" installation dir.
+   *
+   * @param string $path
+   *   The containing directory where it might have been installed.
+   *
+   * @return string
+   *   The directory inside of $path into which the plugin may have been
+   *   installed.
+   */
+  protected function getOriginalDir($path) {
+    return $this->getInstallDir($path);
+  }
+
+  /**
+   * Download and install the plugin.
+   */
+  public function plugin($path = NULL) {
+    if (!$path) {
+      $this->logger()->debug('Acquiring default installation path.');
+      $path = implode('/', [
+        $this->siteAliasManager()->getSelf()->root(),
+        'sites',
+        'all',
+        'libraries',
+      ]);
+      $this->logger()->info('Installing to {0}.', [$path]);
+    }
+
+    $filesystem = new Filesystem();
+
+    // Create the path if it does not exist.
+    if (!is_dir($path)) {
+      $this->fileSystem->mkdir($path);
+      $this->logger()->notice('Directory {0} was created', [$path]);
+    }
+
+    $original_dir = $this->getOriginalDir($path);
+    $install_dir = $this->getInstallDir($path);
+
+    // Download the archive.
+    if ($filepath = system_retrieve_file($this->getDownloadUri(), $path, FALSE, FILE_EXISTS_REPLACE)) {
+
+      // Remove any existing plugin directory.
+      if (is_dir($original_dir) || is_dir($install_dir)) {
+        $filesystem->remove([$original_dir, $install_dir]);
+        $this->logger()->notice('A existing {1} was deleted from {0}', [$path, $this->getDescriptor()]);
+      }
+
+      // Decompress the archive.
+      $this->archiveManager
+        ->getInstance(['filepath' => $filepath])
+        ->extract($install_dir);
+
+      // Change the directory name if needed.
+      if ($original_dir != $install_dir) {
+        $filesystem->rename(
+          $original_dir,
+          $install_dir
+        );
+      }
+    }
+
+    if (is_dir($install_dir)) {
+      $this->logger()->success('{1} has been installed in {0}', [$install_dir, $this->getDescriptor()]);
+    }
+    else {
+      $this->logger()->error('Drush was unable to install the {1} to {0}', [$install_dir, $this->getDescriptor()]);
+    }
+
+  }
+
+}

--- a/src/Commands/AbstractPluginAcquisition.php
+++ b/src/Commands/AbstractPluginAcquisition.php
@@ -10,15 +10,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Drupal\Component\Plugin\PluginManagerInterface;
 
 /**
- * A Drush commandfile.
- *
- * In addition to this file, you need a drush.services.yml
- * in root of your module, and a composer.json file that provides the name
- * of the services file to use.
- *
- * See these files for an example of injecting Drupal services:
- *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
- *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ * Abstract class to hold common code for plugin acquisition.
  */
 abstract class AbstractPluginAcquisition extends DrushCommands implements SiteAliasManagerAwareInterface {
 

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -7,15 +7,7 @@ use Drush\Commands\DrushCommands;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 
 /**
- * A Drush commandfile.
- *
- * In addition to this file, you need a drush.services.yml
- * in root of your module, and a composer.json file that provides the name
- * of the services file to use.
- *
- * See these files for an example of injecting Drupal services:
- *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
- *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ * Drush commandfile for Islandora.
  */
 class IslandoraCommands extends DrushCommands {
 
@@ -40,9 +32,9 @@ class IslandoraCommands extends DrushCommands {
    *   The module for which to install the required objects.
    * @option force
    *   Force reinstallation of the objects.
-   * @usage drush -u 1 ispiro --module=islandora
+   * @usage drush -u1 ispiro --module=islandora
    *   Install missing solution pack objects for the "islandora" module.
-   * @usage drush -u 1 ispiro --module=islandora --force
+   * @usage drush -u1 ispiro --module=islandora --force
    *   Install all solution pack objects for the "islandora" module, purging
    *   any which currently exist.
    * @validate-module-enabled islandora
@@ -79,9 +71,9 @@ class IslandoraCommands extends DrushCommands {
    *   The module for which to uninstall the required objects.
    * @option force
    *   Force uninstallation of the objects.
-   * @usage drush -u 1 ispuro --module=islandora
+   * @usage drush -u1 ispuro --module=islandora
    *   Uninstall solution pack objects for the "islandora" module.
-   * @usage drush -u 1 ispuro --module=islandora --force
+   * @usage drush -u1 ispuro --module=islandora --force
    *   Force uninstallation of all solution pack objects for the "islandora"
    *   module.
    * @validate-module-enabled islandora
@@ -116,9 +108,9 @@ class IslandoraCommands extends DrushCommands {
    *
    * @option module
    *   The module for which to get the status of the required objects.
-   * @usage drush -u 1 ispros
+   * @usage drush -u1 ispros
    *   Get the status of all solution pack objects.
-   * @usage drush -u 1 ispros --module=islandora
+   * @usage drush -u1 ispros --module=islandora
    *   Get the status of solution pack objects for the "islandora" module.
    * @validate-module-enabled islandora
    * @table-style default
@@ -177,7 +169,7 @@ class IslandoraCommands extends DrushCommands {
    *
    * @option module
    *   The module for which to install the content models.
-   * @usage drush -u 1 ispicm --module=islandora
+   * @usage drush -u1 ispicm --module=islandora
    *   Install missing solution pack objects for the "islandora" module.
    * @validate-module-enabled islandora
    *

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -5,7 +5,6 @@ namespace Drupal\islandora\Commands;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drush\Commands\DrushCommands;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Consolidation\OutputFormatters\Options\FormatterOptions;
 
 /**
  * A Drush commandfile.
@@ -20,8 +19,16 @@ use Consolidation\OutputFormatters\Options\FormatterOptions;
  */
 class IslandoraCommands extends DrushCommands {
 
+  /**
+   * Module handler.
+   *
+   * @var Drupal\Core\Extension\ModuleHandlerInterface
+   */
   protected $moduleHandler;
 
+  /**
+   * Constructor.
+   */
   public function __construct(ModuleHandlerInterface $module_handler) {
     $this->moduleHandler = $module_handler;
   }
@@ -29,7 +36,6 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Install Solution Pack objects.
    *
-    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
    * @option module
    *   The module for which to install the required objects.
    * @option force
@@ -37,7 +43,8 @@ class IslandoraCommands extends DrushCommands {
    * @usage drush -u 1 ispiro --module=islandora
    *   Install missing solution pack objects for the "islandora" module.
    * @usage drush -u 1 ispiro --module=islandora --force
-   *   Install all solution pack objects for the "islandora" module, purging any which currently exist.
+   *   Install all solution pack objects for the "islandora" module, purging
+   *   any which currently exist.
    * @validate-module-enabled islandora
    *
    * @command islandora:solution-pack-install-required-objects
@@ -65,7 +72,6 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Uninstall Solution Pack objects.
    *
-    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
    * @option module
    *   The module for which to uninstall the required objects.
    * @option force
@@ -73,7 +79,8 @@ class IslandoraCommands extends DrushCommands {
    * @usage drush -u 1 ispuro --module=islandora
    *   Uninstall solution pack objects for the "islandora" module.
    * @usage drush -u 1 ispuro --module=islandora --force
-   *   Force uninstallation of all solution pack objects for the "islandora" module.
+   *   Force uninstallation of all solution pack objects for the "islandora"
+   *   module.
    * @validate-module-enabled islandora
    *
    * @command islandora:solution-pack-uninstall-required-objects
@@ -101,7 +108,6 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Get Solution Pack object status.
    *
-    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
    * @option module
    *   The module for which to get the status of the required objects.
    * @usage drush -u 1 ispros
@@ -119,7 +125,9 @@ class IslandoraCommands extends DrushCommands {
    *
    * @command islandora:solution-pack-required-objects-status
    * @aliases ispros,islandora-solution-pack-required-objects-status
+   *
    * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+   *   Rows of required object state info.
    */
   public function solutionPackRequiredObjectsStatus(array $options = [
     'module' => self::OPT,
@@ -135,10 +143,9 @@ class IslandoraCommands extends DrushCommands {
       $required_objects = islandora_solution_packs_get_required_objects();
     }
     else {
-      $this->logger()->warning('"{@module}" is not installed/enabled?...', [
+      throw new \Exception(strtr('"@module" is not installed/enabled?...', [
         '@module' => $module,
-      ]);
-      return;
+      ]));
     }
 
     $rows = [];
@@ -160,7 +167,6 @@ class IslandoraCommands extends DrushCommands {
   /**
    * Install Solution Pack content models.
    *
-    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
    * @option module
    *   The module for which to install the content models.
    * @usage drush -u 1 ispicm --module=islandora
@@ -172,7 +178,6 @@ class IslandoraCommands extends DrushCommands {
    */
   public function solutionPackInstallContentModels(array $options = [
     'module' => self::REQ,
-    'asdf' => self::REQ,
   ]) {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
     $module = $options['module'];
@@ -200,7 +205,11 @@ class IslandoraCommands extends DrushCommands {
           $new_object = islandora_add_object($object_to_add);
           $verb = $deleted ? dt("Replaced") : dt("Added");
           if ($new_object) {
-            $this->logger()->notice("{0} {1} - {2}", [$verb, $object_to_add->id, $object_to_add->label]);
+            $this->logger()->notice("{0} {1} - {2}", [
+              $verb,
+              $object_to_add->id,
+              $object_to_add->label,
+            ]);
           }
         }
       }

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -47,6 +47,9 @@ class IslandoraCommands extends DrushCommands {
    *   any which currently exist.
    * @validate-module-enabled islandora
    *
+   * @islandora-user-wrap
+   * @islandora-require-option module
+   *
    * @command islandora:solution-pack-install-required-objects
    * @aliases ispiro,islandora-solution-pack-install-required-objects
    */
@@ -82,6 +85,9 @@ class IslandoraCommands extends DrushCommands {
    *   Force uninstallation of all solution pack objects for the "islandora"
    *   module.
    * @validate-module-enabled islandora
+   *
+   * @islandora-user-wrap
+   * @islandora-require-option module
    *
    * @command islandora:solution-pack-uninstall-required-objects
    * @aliases ispuro,islandora-solution-pack-uninstall-required-objects
@@ -123,6 +129,8 @@ class IslandoraCommands extends DrushCommands {
    *   status_label: Readable Status
    * @default-fields module,pid,status
    *
+   * @islandora-user-wrap
+   *
    * @command islandora:solution-pack-required-objects-status
    * @aliases ispros,islandora-solution-pack-required-objects-status
    *
@@ -130,7 +138,7 @@ class IslandoraCommands extends DrushCommands {
    *   Rows of required object state info.
    */
   public function solutionPackRequiredObjectsStatus(array $options = [
-    'module' => self::OPT,
+    'module' => self::REQ,
   ]) {
     module_load_include('inc', 'islandora', 'includes/solution_packs');
 
@@ -172,6 +180,9 @@ class IslandoraCommands extends DrushCommands {
    * @usage drush -u 1 ispicm --module=islandora
    *   Install missing solution pack objects for the "islandora" module.
    * @validate-module-enabled islandora
+   *
+   * @islandora-user-wrap
+   * @islandora-require-option module
    *
    * @command islandora:solution-pack-install-content_models
    * @aliases ispicm,islandora-solution-pack-install-content_models

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class IslandoraCommands extends DrushCommands {
+
+  /**
+   * Install Solution Pack objects.
+   *
+    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
+   * @option module
+   *   The module for which to install the required objects.
+   * @option force
+   *   Force reinstallation of the objects.
+   * @usage drush -u 1 ispiro --module=islandora
+   *   Install missing solution pack objects for the "islandora" module.
+   * @usage drush -u 1 ispiro --module=islandora --force
+   *   Install all solution pack objects for the "islandora" module, purging any which currently exist.
+   * @validate-module-enabled islandora
+   *
+   * @command islandora:solution-pack-install-required-objects
+   * @aliases ispiro,islandora-solution-pack-install-required-objects
+   */
+  public function solutionPackInstallRequiredObjects(array $options = ['module' => null, 'force' => null]) {
+    // See bottom of https://weitzman.github.io/blog/port-to-drush9 for details on what to change when porting a
+    // legacy command.
+  }
+
+  /**
+   * Uninstall Solution Pack objects.
+   *
+    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
+   * @option module
+   *   The module for which to uninstall the required objects.
+   * @option force
+   *   Force uninstallation of the objects.
+   * @usage drush -u 1 ispuro --module=islandora
+   *   Uninstall solution pack objects for the "islandora" module.
+   * @usage drush -u 1 ispuro --module=islandora --force
+   *   Force uninstallation of all solution pack objects for the "islandora" module.
+   * @validate-module-enabled islandora
+   *
+   * @command islandora:solution-pack-uninstall-required-objects
+   * @aliases ispuro,islandora-solution-pack-uninstall-required-objects
+   */
+  public function solutionPackUninstallRequiredObjects(array $options = ['module' => null, 'force' => null]) {
+    // See bottom of https://weitzman.github.io/blog/port-to-drush9 for details on what to change when porting a
+    // legacy command.
+  }
+
+  /**
+   * Get Solution Pack object status.
+   *
+    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
+   * @option module
+   *   The module for which to get the status of the required objects.
+   * @usage drush -u 1 ispros
+   *   Get the status of all solution pack objects.
+   * @usage drush -u 1 ispros --module=islandora
+   *   Get the status of solution pack objects for the "islandora" module.
+   * @validate-module-enabled islandora
+   *
+   * @command islandora:solution-pack-required-objects-status
+   * @aliases ispros,islandora-solution-pack-required-objects-status
+   */
+  public function solutionPackRequiredObjectsStatus(array $options = ['module' => null]) {
+    // See bottom of https://weitzman.github.io/blog/port-to-drush9 for details on what to change when porting a
+    // legacy command.
+  }
+
+  /**
+   * Install Solution Pack content models.
+   *
+    * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
+   * @option module
+   *   The module for which to install the content models.
+   * @usage drush -u 1 ispicm --module=islandora
+   *   Install missing solution pack objects for the "islandora" module.
+   * @validate-module-enabled islandora
+   *
+   * @command islandora:solution-pack-install-content_models
+   * @aliases ispicm,islandora-solution-pack-install-content_models
+   */
+  public function solutionPackInstallContentModels(array $options = ['module' => null]) {
+    // See bottom of https://weitzman.github.io/blog/port-to-drush9 for details on what to change when porting a
+    // legacy command.
+  }
+
+}

--- a/src/Commands/UserWrapperCommands.php
+++ b/src/Commands/UserWrapperCommands.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\Core\Session\UserSession;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandError;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Drush\Commands\DrushCommands;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+class UserWrapperCommands implements LoggerAwareInterface {
+
+  use LoggerAwareTrait;
+
+  /**
+   * Need access to entities to test users.
+   *
+   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Account switcher to do the switching.
+   *
+   * @var Drupal\Core\Session\AccountSwitcherInterface
+   */
+  protected $switcher;
+
+  /**
+   * The user to which we will switch.
+   *
+   * Either some form of account object, or boolean FALSE.
+   *
+   * @var Drupal\Core\Session\AccountInterface|bool
+   */
+  protected $user = FALSE;
+
+  public function __construct(AccountSwitcherInterface $account_switcher, EntityTypeManagerInterface $entity_type_manager) {
+    $this->switcher = $account_switcher;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Add the option to the command.
+   *
+   * @hook option @islandora-user-wrap
+   */
+  public function userOption(Command $command, AnnotationData $annotationData) {
+    $command->addOption(
+      'user',
+      'u',
+      InputOption::VALUE_REQUIRED,
+      'The Drupal user as whom to run the command.'
+    );
+  }
+
+  /**
+   * Ensure the user provided is valid.
+   *
+   * @hook validate @islandora-user-wrap
+   */
+  public function userExists(CommandData $commandData) {
+    $input = $commandData->input();
+    $user = $input->getOption('user');
+
+    if (!isset($user)) {
+      $this->logger->debug('"user" option does not appear to be set');
+      return;
+    }
+
+    $user_storage = $this->entityTypeManager->getStorage('user');
+    if (is_numeric($user)) {
+      $this->logger->debug('"user" appears to be numeric; loading as-is');
+      $this->user = $user_storage->load($user);
+    }
+    else {
+      $this->logger->debug('"user" is non-numeric; assuming it is a name');
+      $candidates = $user_storage->loadByProperties(['name' => $user]);
+      if (count($candidates) > 1) {
+        return new CommandError(\dt('Too many candidates for user name: @spec', [
+          '@spec' => $user,
+        ]));
+      }
+      $this->user = reset($candidates);
+    }
+
+    if (!$this->user) {
+      return new CommandError(\dt('Failed to load the user: @spec', [
+        '@spec' => $user,
+      ]));
+    }
+  }
+
+  /**
+   * Perform the swap before running the command.
+   *
+   * @hook pre-command @islandora-user-wrap
+   */
+  public function switchUser(CommandData $commandData) {
+    $this->logger->debug('pre-command');
+    if ($this->user) {
+      $this->logger->debug('switching user');
+      $this->switcher->switchTo($this->user);
+      $this->logger->debug('switched user');
+    }
+  }
+
+  /**
+   * Swap back after running the command.
+   *
+   * @hook post-command @islandora-user-wrap
+   */
+  public function unswitch($result, CommandData $commandData) {
+    $this->logger->debug('post-command');
+    if ($this->user) {
+      $this->logger->debug('to switch back');
+      $this->switcher->switchBack();
+      $this->logger->debug('switched back');
+    }
+
+    return $result;
+  }
+
+}

--- a/src/Commands/UserWrapperCommands.php
+++ b/src/Commands/UserWrapperCommands.php
@@ -4,16 +4,21 @@ namespace Drupal\islandora\Commands;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
-use Drupal\Core\Session\UserSession;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandError;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
-use Drush\Commands\DrushCommands;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
+/**
+ * Command wrapper to perform user switching.
+ *
+ * Prior to Drush 9, there was a "--user" option which could be used to run
+ * commands as other users... this command wrapper introduces the
+ * "@islandora-user-wrap" annotation so we can reintroduce it where we want to.
+ */
 class UserWrapperCommands implements LoggerAwareInterface {
 
   use LoggerAwareTrait;
@@ -41,6 +46,9 @@ class UserWrapperCommands implements LoggerAwareInterface {
    */
   protected $user = FALSE;
 
+  /**
+   * Constructor.
+   */
   public function __construct(AccountSwitcherInterface $account_switcher, EntityTypeManagerInterface $entity_type_manager) {
     $this->switcher = $account_switcher;
     $this->entityTypeManager = $entity_type_manager;

--- a/src/Commands/UserWrappingAlterer.php
+++ b/src/Commands/UserWrappingAlterer.php
@@ -29,8 +29,16 @@ class UserWrappingAlterer implements CommandInfoAltererInterface {
     'updatedb',
   ];
 
+  /**
+   * The logger to use.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelInterface
+   */
   protected $logger;
 
+  /**
+   * Constructor.
+   */
   public function __construct(LoggerChannelFactoryInterface $logger_factory) {
     $this->logger = $logger_factory->get('islandora');
   }

--- a/src/Commands/UserWrappingAlterer.php
+++ b/src/Commands/UserWrappingAlterer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Consolidation\AnnotatedCommand\CommandInfoAltererInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+
+/**
+ * Re-create the global --user option.
+ *
+ * XXX: Drush 9 dropped it; however, we require this option for various
+ * commands.
+ */
+class UserWrappingAlterer implements CommandInfoAltererInterface {
+
+  /**
+   * The annotation we use to handle user swapping.
+   */
+  const ANNO = 'islandora-user-wrap';
+
+  /**
+   * The set of commands we wish to alter.
+   */
+  const COMMANDS = [
+    'batch:process',
+  ];
+
+  protected $logger;
+
+  public function __construct(LoggerChannelFactoryInterface $logger_factory) {
+    $this->logger = $logger_factory->get('islandora');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterCommandInfo(CommandInfo $commandInfo, $commandFileInstance) {
+    if (!$commandInfo->hasAnnotation(static::ANNO) && in_array($commandInfo->getName(), static::COMMANDS)) {
+      $this->logger->debug('Adding annotation "@annotation" to @command.', [
+        '@annotation' => static::ANNO,
+        '@command' => $commandInfo->getName(),
+      ]);
+      $commandInfo->addAnnotation(static::ANNO, 'User swapping fun.');
+    }
+  }
+
+}

--- a/src/Commands/UserWrappingAlterer.php
+++ b/src/Commands/UserWrappingAlterer.php
@@ -24,6 +24,9 @@ class UserWrappingAlterer implements CommandInfoAltererInterface {
    */
   const COMMANDS = [
     'batch:process',
+    'pm:enable',
+    'pm:uninstall',
+    'updatedb',
   ];
 
   protected $logger;

--- a/src/Commands/ValidatorCommands.php
+++ b/src/Commands/ValidatorCommands.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\Core\Session\UserSession;
+use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandError;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Drush\Commands\DrushCommands;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Drush\Utils\StringUtils;
+
+class ValidatorCommands implements LoggerAwareInterface {
+
+  use LoggerAwareTrait;
+
+  /**
+   * Ensure the given options are provided.
+   *
+   * @hook validate @islandora-require-option
+   */
+  public function optionExists(CommandData $commandData) {
+    $names = StringUtils::csvToArray($commandData->annotationData()->get('islandora-require-option'));
+
+    $options = $commandData->input()->getOptions();
+
+    $missing = [];
+    foreach ($names as $name) {
+      if (!isset($options[$name])) {
+        $missing[] = $name;
+      }
+    }
+
+    if ($missing) {
+      return new CommandError(\dt('Missing options: !options', [
+        '!options' => implode(',', $missing),
+      ]));
+    }
+  }
+
+}

--- a/src/Commands/ValidatorCommands.php
+++ b/src/Commands/ValidatorCommands.php
@@ -2,19 +2,16 @@
 
 namespace Drupal\islandora\Commands;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Session\AccountSwitcherInterface;
-use Drupal\Core\Session\UserSession;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandError;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Drush\Commands\DrushCommands;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Drush\Utils\StringUtils;
 
+/**
+ * Some misc validators.
+ */
 class ValidatorCommands implements LoggerAwareInterface {
 
   use LoggerAwareTrait;


### PR DESCRIPTION
Drush 9 Compatibility

* https://github.com/drush-ops/drush/pull/2696

# What does this Pull Request do?

This pull makes Islandora's commands compatible with Drush 9.

# What's new?

* Commands have been re-implemented in Drush 9
* Commands have been wrapped to support setting the user
* batches have been wrapped to support setting the user
* helpers have been provided for some common tasks

# How should this be tested?

Attempt to run the drush commands under drush 9.
