### PR TITLE
Consistant object property buttons.

### DIFF
--- a/src/Form/ObjectPropertiesForm.php
+++ b/src/Form/ObjectPropertiesForm.php
@@ -6,7 +6,6 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 use Drupal\Component\Utility\Html;
-use Drupal\Component\Utility\Unicode;
 
 use AbstractObject;
 
@@ -98,12 +97,12 @@ class ObjectPropertiesForm extends FormBase {
       ],
       'submit' => [
         '#type' => 'submit',
-        '#value' => 'Update Properties',
+        '#value' => $this->t('Update Properties'),
       ],
       'delete' => [
         '#type' => 'submit',
         '#access' => islandora_object_access(ISLANDORA_PURGE, $object),
-        '#value' => $this->t("Permanently remove object"),
+        '#value' => $this->t('Delete Object'),
         '#submit' => ['::redirectToDelete'],
         '#limit_validation_errors' => [
           [
@@ -114,7 +113,7 @@ class ObjectPropertiesForm extends FormBase {
       'regenerate' => [
         '#type' => 'submit',
         '#access' => $regenerate_derivatives_access,
-        '#value' => $this->t("Regenerate all derivatives"),
+        '#value' => $this->t('Regenerate Derivatives'),
         '#submit' => ['::redirectToRegenerate'],
       ],
     ];

--- a/src/Form/ObjectPropertiesForm.php
+++ b/src/Form/ObjectPropertiesForm.php
@@ -103,9 +103,7 @@ class ObjectPropertiesForm extends FormBase {
       'delete' => [
         '#type' => 'submit',
         '#access' => islandora_object_access(ISLANDORA_PURGE, $object),
-        '#value' => $this->t("Permanently remove '@label' from repository", [
-          '@label' => Unicode::truncate($object->label, 32, TRUE, TRUE),
-        ]),
+        '#value' => $this->t("Permanently remove object"),
         '#submit' => ['::redirectToDelete'],
         '#limit_validation_errors' => [
           [


### PR DESCRIPTION
Consistent object property buttons.

# What does this Pull Request do?

Changes some of the labels on object properties form.

# What's new?

These are rather inconsistent and including the object label is redundant. They are now consistent and work well with the override in the collection SP.

# How should this be tested?

Go to an object properties page and see the new button labels.