### PR TITLE
Fix the "NodeHasTerm" condition double-negation

### DIFF
--- a/src/Plugin/Condition/NodeHasTerm.php
+++ b/src/Plugin/Condition/NodeHasTerm.php
@@ -150,13 +150,13 @@ class NodeHasTerm extends ConditionPluginBase implements ContainerFactoryPluginI
         if (!$field->isEmpty()) {
           $link = $field->first()->getValue();
           if ($link['uri'] == $this->configuration['uri']) {
-            return $this->isNegated() ? FALSE : TRUE;
+            return TRUE;
           }
         }
       }
     }
 
-    return $this->isNegated() ? TRUE : FALSE;
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
The evaluation of the condition already performs the negation: https://git.drupalcode.org/project/drupal/blob/923909159ead3521abc99ea0e4936d1e7bb6dce2/core/lib/Drupal/Core/Condition/ConditionManager.php#L77

... so prevent the double-negation from occurring...

# What does this Pull Request do?

Prevents the double-negation.

# What's new?

Negation of the condition works.

# How should this be tested?

Configure the condition with a negation (e.g., matching nodes which are _not_ collections).